### PR TITLE
Fix dev-lang/mono-9999 build (src_prepare())

### DIFF
--- a/dev-lang/mono/mono-9999.ebuild
+++ b/dev-lang/mono/mono-9999.ebuild
@@ -45,7 +45,6 @@ pkg_setup() {
 
 src_prepare() {
 	cat "${S}/mono/mini/Makefile.am.in" > "${S}/mono/mini/Makefile.am" || die
-	cat "${S}/mono/metadata/Makefile.am.in" > "${S}/mono/metadata/Makefile.am" || die
 
 	eautoreconf
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't


### PR DESCRIPTION
Mono upstream no longer has mono/metadata/Makefile.am named mono/metadata/Makefile.am.in.  Trying to duplicate Makefile.am.in to Makefile.am is therefore pointless.  Removing this line allows src_prepare to succeed.  Change occurred in upstream at commit ( mono/mono@ad8236ebb857acf1459d7c87b85df82918dc2313 ).
