### PR TITLE
build: Disable git integration, remedy binding

### DIFF
--- a/dev-util/monodevelop/monodevelop-5.0.1.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.0.1.ebuild
@@ -37,6 +37,15 @@ DEPEND="${RDEPEND}
 	x11-terms/xterm"
 MAKEOPTS="${MAKEOPTS} -j1" #nowarn
 
+src_prepare() {
+	# Remove the git rev-parse (changelog?)
+	sed -i '/<Exec.*rev-parse/ d' ${S}/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj || die
+
+	# Set specific_version to prevent binding problem
+	# when gtk#-3 is installed alongside gtk#-2
+	find ${S} -name '*.csproj' -exec sed -i 's#<SpecificVersion>.*</SpecificVersion>#<SpecificVersion>True</SpecificVersion>#' {} + || die
+}
+
 src_configure() {
 	econf \
 		--disable-update-mimedb \


### PR DESCRIPTION
Git integration was causing a failed build with the 5.0.1 ebuild since
the git repository is understandably missing in the tarball. In
addition, on systems where gtk#-3 is also installed the build
experiences binding version mismatches (particularly with gdk-sharp and
glib-sharp).

This patch removes the git execution and sets specific_version for
libraries with judicial use of sed.