### PR TITLE
Fix for ${FRAMEWORK} variable

### DIFF
--- a/dev-util/monodevelop/monodevelop-5.7.0-r1.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.7.0-r1.ebuild
@@ -60,7 +60,8 @@ src_prepare() {
 	cp -fR "${WORKDIR}"/NUnit-2.6.3/bin/framework/* "${S}"/packages/NUnit.2.6.3/lib
 	cp -fR "${WORKDIR}"/NUnit-2.6.3/bin/lib/* "${S}"/packages/NUnit.Runners.2.6.3/tools/lib/ || die
 	cp -fR "${WORKDIR}"/NUnit-2.5.10.11092/bin/net-2.0/framework/* "${S}"/external/cecil/Test/libs/nunit-2.5.10/ || die
-	ln -s /usr/lib/mono/NuGet/* "${S}"/external/nuget-binary/ || die
+	ln -s /usr/lib/mono/NuGet/${FRAMEWORK}/NuGet.Core.dll "${S}"/external/nuget-binary/ || die
+	ln -s /usr/lib/mono/NuGet/${FRAMEWORK}/NuGet.exe "${S}"/external/nuget-binary/ || die
 
 	# https://github.com/gentoo/dotnet/issues/30
 	epatch "${FILESDIR}/gentoo-dotnet-issue-30.patch"

--- a/dev-util/monodevelop/monodevelop-5.7.0-r1.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.7.0-r1.ebuild
@@ -3,6 +3,9 @@
 # $Header: $
 
 EAPI="5"
+
+USE_DOTNET="net45"
+
 inherit fdo-mime gnome2-utils dotnet versionator eutils
 
 DESCRIPTION="Integrated Development Environment for .NET"


### PR DESCRIPTION
I am not sure, that it is good idea to add variable USE_DOTNET="net45" to each ebuild