### PR TITLE
monodevelop depends on gtk-sharp:2

### DIFF
--- a/dev-util/monodevelop/monodevelop-5.9.0.431.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.9.0.431.ebuild
@@ -25,7 +25,7 @@ IUSE="+subversion +git doc +gnome qtcurve"
 RDEPEND=">=dev-lang/mono-3.2.8
 	>=dev-dotnet/nuget-2.8.3
 	gnome? ( >=dev-dotnet/gnome-sharp-2.24.2-r1 )
-	>=dev-dotnet/gtk-sharp-2.12.21
+	>=dev-dotnet/gtk-sharp-2.12.21:2
 	>=dev-dotnet/mono-addins-1.0[gtk]
 	doc? ( dev-util/mono-docbrowser )
 	>=dev-dotnet/xsp-2


### PR DESCRIPTION
Use slot dependency so `gtk-sharp-2.99.1:3` isn't pulled in instead.