### PR TITLE
Added ebuild for monodevelop-5.9.5.5 (github)

### DIFF
--- a/dev-util/monodevelop/files/5.9.5-kill-gnome.patch
+++ b/dev-util/monodevelop/files/5.9.5-kill-gnome.patch
@@ -1,0 +1,153 @@
+diff -rupN main.original/configure.in main/configure.in
+--- main.original/configure.in	2015-07-18 14:09:27.934561734 +0200
++++ main/configure.in	2015-07-18 14:11:02.182316682 +0200
+@@ -133,13 +133,6 @@ PKG_CHECK_MODULES(MONODOC, monodoc >= $M
+ AC_SUBST(MONODOC_LIBS)
+ 
+ dnl soft dependencies
+-PKG_CHECK_MODULES(GNOME_SHARP, gnome-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_sharp=yes], [gnome_sharp=no])
+-AC_SUBST(GNOME_SHARP_LIBS)
+-PKG_CHECK_MODULES(GNOME_VFS_SHARP, gnome-vfs-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gnome_vfs_sharp=yes], [gnome_vfs_sharp=no])
+-AC_SUBST(GNOME_VFS_SHARP_LIBS)
+-PKG_CHECK_MODULES(GCONF_SHARP, gconf-sharp-2.0 >= $GTKSHARP_REQUIRED_VERSION, [gconf_sharp=yes], [gconf_sharp=no])
+-AC_SUBST(GCONF_SHARP_LIBS)
+-
+ gtksharp_prefix="`$PKG_CONFIG --variable=prefix gtk-sharp-2.0`"
+ AC_SUBST(gtksharp_prefix)
+ 
+diff -rupN main.original/src/addins/GnomePlatform/GnomePlatform.cs main/src/addins/GnomePlatform/GnomePlatform.cs
+--- main.original/src/addins/GnomePlatform/GnomePlatform.cs	2015-07-18 18:40:15.946222126 +0200
++++ main/src/addins/GnomePlatform/GnomePlatform.cs	2015-07-18 19:56:35.272686234 +0200
+@@ -26,7 +26,6 @@
+ // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ //
+ 
+-using Gnome;
+ using MonoDevelop.Ide.Desktop;
+ using System;
+ using System.Collections.Generic;
+@@ -40,44 +39,13 @@ namespace MonoDevelop.Platform
+ {
+ 	public class GnomePlatform : PlatformService
+ 	{
+-		static bool useGio;
+-
+-		Gnome.ThumbnailFactory thumbnailFactory = new Gnome.ThumbnailFactory (Gnome.ThumbnailSize.Normal);
+-
+ 		static GnomePlatform ()
+ 		{
+ 			try {
+ 				Gio.GetDefaultForType ("text/plain");
+-				useGio = true;
+ 			} catch (Exception ex) {
+ 				Console.WriteLine (ex);
+ 			}
+-			//apparently Gnome.Icon needs GnomeVFS initialized even when we're using GIO.
+-			Gnome.Vfs.Vfs.Initialize ();
+-		}
+-		
+-		DesktopApplication GetGnomeVfsDefaultApplication (string mimeType)
+-		{
+-			var app = Gnome.Vfs.Mime.GetDefaultApplication (mimeType);
+-			if (app != null)
+-				return (DesktopApplication) Marshal.PtrToStructure (app.Handle, typeof(DesktopApplication));
+-			else
+-				return null;
+-		}
+-		
+-		IEnumerable<DesktopApplication> GetGnomeVfsApplications (string mimeType)
+-		{
+-			var def = GetGnomeVfsDefaultApplication (mimeType);
+-			var list = new List<DesktopApplication> ();
+-			var apps = Gnome.Vfs.Mime.GetAllApplications (mimeType);
+-			foreach (var app in apps) {
+-				var dap = (GnomeVfsApp) Marshal.PtrToStructure (app.Handle, typeof(GnomeVfsApp));
+-				if (!string.IsNullOrEmpty (dap.Command) && !string.IsNullOrEmpty (dap.DisplayName) && !dap.Command.Contains ("monodevelop ")) {
+-					var isDefault = def != null && def.Id == dap.Command;
+-					list.Add (new GnomeDesktopApplication (dap.Command, dap.DisplayName, isDefault));
+-				}
+-			}
+-			return list;
+ 		}
+ 		
+ 		public override IEnumerable<DesktopApplication> GetApplications (string filename)
+@@ -88,10 +56,7 @@ namespace MonoDevelop.Platform
+ 
+ 		IEnumerable<DesktopApplication> GetApplicationsForMimeType (string mimeType)
+ 		{
+-			if (useGio)
+-				return Gio.GetAllForType (mimeType);
+-			else
+-				return GetGnomeVfsApplications (mimeType);
++			return Gio.GetAllForType (mimeType);
+ 		}
+ 		
+ 		struct GnomeVfsApp {
+@@ -100,23 +65,15 @@ namespace MonoDevelop.Platform
+ 
+ 		protected override string OnGetMimeTypeDescription (string mt)
+ 		{
+-			if (useGio)
+-				return Gio.GetMimeTypeDescription (mt);
+-			else
+-				return Gnome.Vfs.Mime.GetDescription (mt);
++			return Gio.GetMimeTypeDescription (mt);
+ 		}
+ 
+ 		protected override string OnGetMimeTypeForUri (string uri)
+ 		{
+ 			if (uri == null)
+ 				return null;
+-			
+-			if (useGio) {
+-				string mt = Gio.GetMimeTypeForUri (uri);
+-				if (mt != null)
+-					return mt;
+-			}
+-			return Gnome.Vfs.MimeType.GetMimeTypeForUri (ConvertFileNameToVFS (uri));
++
++			return Gio.GetMimeTypeForUri (uri);
+ 		}
+ 		
+ 		protected override bool OnGetMimeTypeIsText (string mimeType)
+@@ -128,19 +85,9 @@ namespace MonoDevelop.Platform
+ 			return base.OnGetMimeTypeIsText (mimeType);
+ 		}
+ 
+-
+-		public override void ShowUrl (string url)
+-		{
+-			Gnome.Url.Show (url);
+-		}
+-		
+ 		public override string DefaultMonospaceFont {
+ 			get {
+-				try {
+-					return (string) (new GConf.Client ().Get ("/desktop/gnome/interface/monospace_font_name"));
+-				} catch (Exception) {
+-					return "Monospace 11";
+-				}
++				return "Monospace 11";
+ 			}
+ 		}
+ 		
+@@ -159,18 +106,8 @@ namespace MonoDevelop.Platform
+ 				filename = EscapeFileName (filename);
+ 				if (filename == null)
+ 					return "gnome-fs-regular";
+-				
+-				string icon = null;
+-				Gnome.IconLookupResultFlags result;
+-				try {
+-					icon = Gnome.Icon.LookupSync (IconTheme.Default, thumbnailFactory, filename, null, 
+-					                              Gnome.IconLookupFlags.None, out result);
+-				} catch {}
+-				if (icon != null && icon.Length > 0)
+-					return icon;
+-			}			
++			}
+ 			return "gnome-fs-regular";
+-			
+ 		}
+ 		
+ 		protected override Xwt.Drawing.Image OnGetIconForFile (string filename)

--- a/dev-util/monodevelop/files/5.9.5-skip_merged_tar.patch
+++ b/dev-util/monodevelop/files/5.9.5-skip_merged_tar.patch
@@ -1,0 +1,11 @@
+--- monodevelop-5.9.5.5.orig/Makefile	2015-07-18 18:40:15.414229154 +0200
++++ monodevelop-5.9.5.5/Makefile	2015-07-18 19:39:03.782576863 +0200
+@@ -87,8 +87,6 @@ dist: update_submodules remove-stale-tar
+ 		-name \*.dll -o \
+ 		-name \*.mdb \) \
+ 		-delete
+-	@cd tarballs && tar -cjf monodevelop-$(PACKAGE_VERSION).tar.bz2 monodevelop-$(PACKAGE_VERSION)
+-	@cd tarballs && rm -rf monodevelop-$(PACKAGE_VERSION)
+ 
+ aot:
+ 	@for i in main/build/bin/*.dll; do ($(MONO_AOT) $$i &> /dev/null && echo AOT successful: $$i) || (echo AOT failed: $$i); done

--- a/dev-util/monodevelop/monodevelop-5.9.5.5.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.9.5.5.ebuild
@@ -1,0 +1,141 @@
+# Copyright 1999-2015 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Header: $
+
+EAPI=5
+inherit fdo-mime gnome2-utils dotnet versionator eutils git-r3
+
+DESCRIPTION="Integrated Development Environment for .NET"
+HOMEPAGE="http://www.monodevelop.com/"
+SRC_URI="https://launchpadlibrarian.net/68057829/NUnit-2.5.10.11092.zip
+	https://www.nuget.org/api/v2/package/NUnit/2.6.3 -> NUnit.2.6.3.zip
+	https://www.nuget.org/api/v2/package/NUnit.Runners/2.6.3  -> NUnit.Runners.2.6.3.zip
+	https://www.nuget.org/api/v2/package/System.Web.Mvc.Extensions.Mvc.4/1.0.9 -> System.Web.Mvc.Extensions.Mvc.4.1.0.9.zip
+	https://www.nuget.org/api/v2/package/Microsoft.AspNet.Mvc/5.2.2 -> Microsoft.AspNet.Mvc.5.2.2.zip
+	https://www.nuget.org/api/v2/package/Microsoft.AspNet.Razor/3.2.2 -> Microsoft.AspNet.Razor.3.2.2.zip
+	https://www.nuget.org/api/v2/package/Microsoft.AspNet.WebPages/3.2.2 -> Microsoft.AspNet.WebPages.3.2.2.zip
+	https://www.nuget.org/api/v2/package/Microsoft.Web.Infrastructure/1.0.0.0 -> Microsoft.Web.Infrastructure.1.0.0.0.zip"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="+subversion +git doc +gnome qtcurve"
+
+RDEPEND=">=dev-lang/mono-3.2.8
+	>=dev-dotnet/nuget-2.8.3
+	gnome? ( >=dev-dotnet/gnome-sharp-2.24.2-r1 )
+	>=dev-dotnet/gtk-sharp-2.12.21:2
+	>=dev-dotnet/mono-addins-1.0[gtk]
+	doc? ( dev-util/mono-docbrowser )
+	>=dev-dotnet/xsp-2
+	dev-util/ctags
+	sys-apps/dbus[X]
+	subversion? ( dev-vcs/subversion )
+	!<dev-util/monodevelop-boo-$(get_version_component_range 1-2)
+	!<dev-util/monodevelop-java-$(get_version_component_range 1-2)
+	!<dev-util/monodevelop-database-$(get_version_component_range 1-2)
+	!<dev-util/monodevelop-debugger-gdb-$(get_version_component_range 1-2)
+	!<dev-util/monodevelop-debugger-mdb-$(get_version_component_range 1-2)
+	!<dev-util/monodevelop-vala-$(get_version_component_range 1-2)"
+DEPEND="${RDEPEND}
+	dev-util/intltool
+	virtual/pkgconfig
+	sys-devel/gettext
+	x11-misc/shared-mime-info
+	x11-terms/xterm
+	app-arch/unzip"
+MAKEOPTS="${MAKEOPTS} -j1" #nowarn
+S="${WORKDIR}"/${P}
+EGIT_REPO_URI="https://github.com/mono/monodevelop.git"
+EGIT_COMMIT="${P}"
+
+src_unpack() {
+	cd "${T}"
+	unpack NUnit-2.5.10.11092.zip
+
+	#clone from git
+	git-r3_fetch
+	git-r3_checkout "${EGIT_REPO_URI}" "${T}/${P}"
+
+	#extract packages
+	mkdir -p "${T}"/packages || die
+	cd "${T}"/packages || die
+
+	for pkg in NUnit.2.6.3 \
+				NUnit.Runners.2.6.3 \
+				System.Web.Mvc.Extensions.Mvc.4.1.0.9 \
+				Microsoft.AspNet.Mvc.5.2.2 \
+				Microsoft.AspNet.Razor.3.2.2 \
+				Microsoft.AspNet.WebPages.3.2.2 \
+				Microsoft.Web.Infrastructure.1.0.0.0
+	do
+		mkdir $pkg || die
+		cd $pkg || die
+		unpack $pkg.zip
+		cd .. || die
+	done
+	mkdir -p "${S}"
+}
+
+src_prepare() {
+	# Remove the git rev-parse (changelog?)
+	sed -i '/<Exec.*rev-parse/ d' "${T}/${P}/main/src/core/MonoDevelop.Core/MonoDevelop.Core.csproj" || die
+	# Set specific_version to prevent binding problem
+	# when gtk#-3 is installed alongside gtk#-2
+	find "${T}/${P}" -name '*.csproj' -exec sed -i 's#<SpecificVersion>.*</SpecificVersion>#<SpecificVersion>True</SpecificVersion>#' {} + || die
+
+	#fix ASP.Net
+	cd "${T}/${P}/main"
+	epatch "${FILESDIR}/5.7-downgrade_to_mvc3.patch"
+	
+	# fix for https://github.com/gentoo/dotnet/issues/42
+	epatch "${FILESDIR}/aspnet-template-references-fix.patch"
+	use gnome || epatch "${FILESDIR}/5.9.5-kill-gnome.patch"
+	use qtcurve && epatch "${FILESDIR}/kill-qtcurve-warning.patch"
+	
+	#prepare dist package
+	cd "${T}/${P}"
+	epatch "${FILESDIR}/5.9.5-skip_merged_tar.patch"
+	./configure --profile=default || die
+	make dist || die
+	
+	#move it
+	mv -f "${T}/${P}/tarballs/"monodevelop-*/* "${S}" || die
+
+	#copy missing binaries
+	mkdir -p "${S}"/external/cecil/Test/libs/nunit-2.5.10/ || die
+	cp -fR "${T}"/NUnit-2.5.10.11092/bin/net-2.0/framework/* "${S}"/external/cecil/Test/libs/nunit-2.5.10/ || die
+	mv -f "${T}/packages" "${S}"
+}
+
+src_configure() {
+	# env vars are added as the fix for https://github.com/gentoo/dotnet/issues/29
+	MCS=/usr/bin/dmcs CSC=/usr/bin/dmcs GMCS=/usr/bin/dmcs econf \
+		--disable-update-mimedb \
+		--disable-update-desktopdb \
+		--enable-monoextensions \
+		--enable-gnomeplatform \
+		$(use_enable subversion) \
+		$(use_enable git)
+	# https://github.com/mrward/xdt/issues/4
+	# Main.sln file is created on the fly during econf
+	epatch -p2 "${FILESDIR}/mrward-xdt-issue-4.patch"
+	# fix of https://github.com/gentoo/dotnet/issues/38
+	sed -i -E -e 's#(EXE_PATH=")(.*)(/lib/monodevelop/bin/MonoDevelop.exe")#\1'${EPREFIX}'/usr\3#g' "${S}/monodevelop" || die
+}
+
+pkg_preinst() {
+	gnome2_icon_savelist
+}
+
+pkg_postinst() {
+	gnome2_icon_cache_update
+	fdo-mime_mime_database_update
+	fdo-mime_desktop_database_update
+}
+
+pkg_postrm() {
+	gnome2_icon_cache_update
+	fdo-mime_mime_database_update
+	fdo-mime_desktop_database_update
+}


### PR DESCRIPTION
Well this seems to be somehow hackish :)

It makes this:
- clone monodevelop from github using versioned tag
- call configure and make dist to prepare dir which is normally delivered with all external libraries fetched too (they are not included in githubs packages)
- use prepared dir as before

I needed to alter some patches and create new one
It seems to work for me at least so I hope it can be usefull - maybe create monodevelop-9999 from it too (should work with little tweaking)?