### PR TITLE
dev-lang/mono-4.0.2.5.ebuild improvements

### DIFF
--- a/dev-lang/mono/files/mono-4.0.2.5-fix-decimal-ms-on-big-endian.patch
+++ b/dev-lang/mono/files/mono-4.0.2.5-fix-decimal-ms-on-big-endian.patch
@@ -1,0 +1,22 @@
+diff -up mono/metadata/decimal-ms.c.than
+mono/metadata/decimal-ms.c
+--- mono/metadata/decimal-ms.c.than  2015-07-06 08:21:27.524461795
+-0400
++++ mono/metadata/decimal-ms.c       2015-07-06 08:30:26.954461795
+-0400
+@@ -55,8 +55,13 @@ static const uint32_t ten_to_ten_div_4 =
+ #define DECIMAL_LO32(dec)        ((dec).v.v.Lo32)
+ #define DECIMAL_MID32(dec)       ((dec).v.v.Mid32)
+ #define DECIMAL_HI32(dec)        ((dec).Hi32)
+-#define DECIMAL_LO64_GET(dec)    ((dec).v.Lo64)
+-#define DECIMAL_LO64_SET(dec,value)   {(dec).v.Lo64 = value; }
++#if G_BYTE_ORDER != G_LITTLE_ENDIAN
++# define DECIMAL_LO64_GET(dec)   (((uint64_t)((dec).v.v.Mid32) << 32) | (dec).v.v.Lo32)
++# define DECIMAL_LO64_SET(dec,value)   {(dec).v.v.Lo32 = (value); (dec).v.v.Mid32 = ((value) >> 32); }
++#else
++# define DECIMAL_LO64_GET(dec)    ((dec).v.Lo64)
++# define DECIMAL_LO64_SET(dec,value)   {(dec).v.Lo64 = value; }
++#endif
+
+ #define DECIMAL_SETZERO(dec) {DECIMAL_LO32(dec) = 0; DECIMAL_MID32(dec) = 0; DECIMAL_HI32(dec) = 0; DECIMAL_SIGNSCALE(dec) = 0;}
+ #define COPYDEC(dest, src) {DECIMAL_SIGNSCALE(dest) = DECIMAL_SIGNSCALE(src); DECIMAL_HI32(dest) = DECIMAL_HI32(src); \

--- a/dev-lang/mono/files/mono-4.0.2.5-fix-mono-dis-makefile-am-when-without-sgen.patch
+++ b/dev-lang/mono/files/mono-4.0.2.5-fix-mono-dis-makefile-am-when-without-sgen.patch
@@ -1,0 +1,15 @@
+===================================================================
+RCS file: mono/dis/RCS/Makefile.am,v
+retrieving revision 1.1
+diff -up -r1.1 mono/dis/Makefile.am
+--- mono/dis/Makefile.am	2015/05/08 15:00:22	1.1
++++ mono/dis/Makefile.am	2015/07/14 11:20:29
+@@ -7,7 +7,7 @@ endif
+ if SUPPORT_SGEN
+ metadata_lib=$(top_builddir)/mono/metadata/libmonoruntimesgen-static.la
+ else
+-metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime-static.a
++metadata_lib=$(top_builddir)/mono/metadata/libmonoruntime-static.la
+ gc_lib=$(LIBGC_STATIC_LIBS)
+ endif
+ 

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -80,7 +80,6 @@ src_prepare() {
 src_configure() {
 	local myeconfargs=(
 		--disable-silent-rules
-		--with-libgdiplus=$(usex minimal no installed)
 		$(use_with xen xen_opt)
 		--without-ikvm-native
 		--with-jit

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -78,15 +78,11 @@ src_prepare() {
 }
 
 src_configure() {
-	# --without-moonlight since www-plugins/moonlight is not the only one
-	# using mono: https://bugzilla.novell.com/show_bug.cgi?id=641005#c3
-	#
 	# --with-profile4 needs to be always enabled since it's used by default
 	# and, otherwise, problems like bug #340641 appear.
 	local myeconfargs=(
 		--enable-system-aot=yes
 		--disable-quiet-build
-		--without-moonlight
 		--with-libgdiplus=$(usex minimal no installed)
 		$(use_with xen xen_opt)
 		--without-ikvm-native

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -79,7 +79,7 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
-		--disable-quiet-build
+		--disable-silent-rules
 		--with-libgdiplus=$(usex minimal no installed)
 		$(use_with xen xen_opt)
 		--without-ikvm-native

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -78,9 +78,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# NOTE: We need the static libs for now so mono-debugger works.
-	# See http://bugs.gentoo.org/show_bug.cgi?id=256264 for details
-	#
 	# --without-moonlight since www-plugins/moonlight is not the only one
 	# using mono: https://bugzilla.novell.com/show_bug.cgi?id=641005#c3
 	#
@@ -88,7 +85,6 @@ src_configure() {
 	# and, otherwise, problems like bug #340641 appear.
 	local myeconfargs=(
 		--enable-system-aot=yes
-		--enable-static
 		--disable-quiet-build
 		--without-moonlight
 		--with-libgdiplus=$(usex minimal no installed)

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -6,7 +6,7 @@ EAPI=5
 AUTOTOOLS_PRUNE_LIBTOOL_FILES="all"
 AUTOTOOLS_AUTORECONF=1
 
-inherit eutils linux-info mono-env flag-o-matic pax-utils autotools-utils
+inherit eutils linux-info mono-env flag-o-matic pax-utils autotools-utils versionator
 
 DESCRIPTION="Mono runtime and class libraries, a C# compiler/interpreter"
 HOMEPAGE="http://www.mono-project.com/Main_Page"
@@ -34,7 +34,7 @@ DEPEND="${COMMONDEPEND}
 "
 
 MAKEOPTS="${MAKEOPTS} -j1" #nowarn
-S="${WORKDIR}/${PN}-4.0.2"
+S="${WORKDIR}/${PN}-$(get_version_component_range 1-3)"
 
 pkg_pretend() {
 	# If CONFIG_SYSVIPC is not set in your kernel .config, mono will hang while compiling.

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -62,9 +62,6 @@ src_prepare() {
 	# mono build system can fail otherwise
 	strip-flags
 
-	# Remove this at your own peril. Mono will barf in unexpected ways.
-	append-flags -fno-strict-aliasing
-
 	#fix vb targets http://osdir.com/ml/general/2015-05/msg20808.html
 	epatch "${FILESDIR}/add_missing_vb_portable_targets.patch"
 

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -21,7 +21,7 @@ IUSE="nls minimal pax_kernel xen doc"
 
 COMMONDEPEND="
 	!minimal? ( >=dev-dotnet/libgdiplus-2.10 )
-	ia64? (	sys-libs/libunwind )
+	ia64? ( sys-libs/libunwind )
 	nls? ( sys-devel/gettext )
 "
 RDEPEND="${COMMONDEPEND}
@@ -34,6 +34,7 @@ DEPEND="${COMMONDEPEND}
 "
 
 MAKEOPTS="${MAKEOPTS} -j1" #nowarn
+
 S="${WORKDIR}/${PN}-$(get_version_component_range 1-3)"
 
 pkg_pretend() {
@@ -62,7 +63,8 @@ src_prepare() {
 	# mono build system can fail otherwise
 	strip-flags
 
-	#fix vb targets http://osdir.com/ml/general/2015-05/msg20808.html
+	# Fix VB targets
+	# http://osdir.com/ml/general/2015-05/msg20808.html
 	epatch "${FILESDIR}/add_missing_vb_portable_targets.patch"
 
 	# Fix build on big-endian machines
@@ -74,6 +76,7 @@ src_prepare() {
 	epatch "${FILESDIR}/${P}-fix-mono-dis-makefile-am-when-without-sgen.patch"
 
 	autotools-utils_src_prepare
+
 	epatch "${FILESDIR}/systemweb3.patch"
 }
 

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -82,7 +82,6 @@ src_configure() {
 		--disable-silent-rules
 		$(use_with xen xen_opt)
 		--without-ikvm-native
-		--with-jit
 		--disable-dtrace
 		$(use_with doc mcs-docs)
 		$(use_enable debug)

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -88,15 +88,6 @@ src_configure() {
 	)
 
 	autotools-utils_src_configure
-
-	# FIX for uncompilable 3.4.0 sources
-	FF="${WORKDIR}/mono-3.4.0/mcs/tools/xbuild/targets/Microsoft.Portable.Common.targets"
-	rm -f $FF
-	touch $FF
-	echo '<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">' >> $FF
-	echo '    <Import Project="..\\Microsoft.Portable.Core.props" />' >> $FF
-	echo '    <Import Project="..\\Microsoft.Portable.Core.targets" />' >> $FF
-	echo '</Project>' >> $FF
 }
 
 src_compile() {

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -79,7 +79,6 @@ src_prepare() {
 
 src_configure() {
 	local myeconfargs=(
-		--enable-system-aot=yes
 		--disable-quiet-build
 		--with-libgdiplus=$(usex minimal no installed)
 		$(use_with xen xen_opt)

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -78,8 +78,6 @@ src_prepare() {
 }
 
 src_configure() {
-	# --with-profile4 needs to be always enabled since it's used by default
-	# and, otherwise, problems like bug #340641 appear.
 	local myeconfargs=(
 		--enable-system-aot=yes
 		--disable-quiet-build
@@ -88,7 +86,6 @@ src_configure() {
 		--without-ikvm-native
 		--with-jit
 		--disable-dtrace
-		--with-profile4
 		$(use_with doc mcs-docs)
 		$(use_enable debug)
 		$(use_enable nls)

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -4,6 +4,7 @@
 
 EAPI=5
 AUTOTOOLS_PRUNE_LIBTOOL_FILES="all"
+AUTOTOOLS_AUTORECONF=1
 
 inherit eutils linux-info mono-env flag-o-matic pax-utils autotools-utils
 
@@ -70,6 +71,10 @@ src_prepare() {
 	# Fix build on big-endian machines
 	# https://bugzilla.xamarin.com/show_bug.cgi?id=31779
 	epatch "${FILESDIR}/${P}-fix-decimal-ms-on-big-endian.patch"
+
+	# Fix build --without-sgen
+	# https://bugzilla.xamarin.com/show_bug.cgi?id=32015
+	epatch "${FILESDIR}/${P}-fix-mono-dis-makefile-am-when-without-sgen.patch"
 
 	autotools-utils_src_prepare
 	epatch "${FILESDIR}/systemweb3.patch"

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 
 KEYWORDS="~amd64 ~ppc ~ppc64 ~x86 ~amd64-linux"
 
-IUSE="nls minimal pax_kernel xen doc debug"
+IUSE="nls minimal pax_kernel xen doc"
 
 COMMONDEPEND="
 	!minimal? ( >=dev-dotnet/libgdiplus-2.10 )
@@ -84,7 +84,6 @@ src_configure() {
 		--without-ikvm-native
 		--disable-dtrace
 		$(use_with doc mcs-docs)
-		$(use_enable debug)
 		$(use_enable nls)
 	)
 

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -72,7 +72,7 @@ src_prepare() {
 	# https://bugzilla.xamarin.com/show_bug.cgi?id=31779
 	epatch "${FILESDIR}/${P}-fix-decimal-ms-on-big-endian.patch"
 
-	# Fix build --without-sgen
+	# Fix build when sgen disabled
 	# https://bugzilla.xamarin.com/show_bug.cgi?id=32015
 	epatch "${FILESDIR}/${P}-fix-mono-dis-makefile-am-when-without-sgen.patch"
 
@@ -89,8 +89,6 @@ src_configure() {
 	#
 	# --with-profile4 needs to be always enabled since it's used by default
 	# and, otherwise, problems like bug #340641 appear.
-	#
-	# sgen fails on ppc, bug #359515
 	local myeconfargs=(
 		--enable-system-aot=yes
 		--enable-static
@@ -102,7 +100,6 @@ src_configure() {
 		--with-jit
 		--disable-dtrace
 		--with-profile4
-		--with-sgen=$(usex ppc no yes)
 		$(use_with doc mcs-docs)
 		$(use_enable debug)
 		$(use_enable nls)

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -91,10 +91,7 @@ src_configure() {
 }
 
 src_compile() {
-	nonfatal autotools-utils_src_compile || {
-		eqawarn "maintainer of this ebuild has no idea why it fails. If you happen to know how to fix it - please let me know"
-		autotools-utils_src_compile
-	 }
+	autotools-utils_src_compile
 }
 
 src_test() {

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -67,6 +67,10 @@ src_prepare() {
 	#fix vb targets http://osdir.com/ml/general/2015-05/msg20808.html
 	epatch "${FILESDIR}/add_missing_vb_portable_targets.patch"
 
+	# Fix build on big-endian machines
+	# https://bugzilla.xamarin.com/show_bug.cgi?id=31779
+	epatch "${FILESDIR}/${P}-fix-decimal-ms-on-big-endian.patch"
+
 	autotools-utils_src_prepare
 	epatch "${FILESDIR}/systemweb3.patch"
 }


### PR DESCRIPTION
- Patches to fix build for big-endian and without-sgen
- Bring configure switches in line with reality
- Other minor improvements