### PR TITLE
Removed dev-dotnet/mono-addins from the latest monodevelop's dependencies

### DIFF
--- a/dev-util/monodevelop/monodevelop-5.9.5.5.ebuild
+++ b/dev-util/monodevelop/monodevelop-5.9.5.5.ebuild
@@ -25,7 +25,6 @@ RDEPEND=">=dev-lang/mono-3.2.8
 	>=dev-dotnet/nuget-2.8.3
 	gnome? ( >=dev-dotnet/gnome-sharp-2.24.2-r1 )
 	>=dev-dotnet/gtk-sharp-2.12.21:2
-	>=dev-dotnet/mono-addins-1.0[gtk]
 	doc? ( dev-util/mono-docbrowser )
 	>=dev-dotnet/xsp-2
 	dev-util/ctags


### PR DESCRIPTION
I removed dev-dotnet/mono-addins from the latest monodevelop's (5.9.5.5) dependencies, which appears to have been unnecessary. mono-addins refuses to bulid without `gmcs` which doesn't look like it has been included in Mono 4, and monodevelop builds and runs fine without it. I'm not very familiar with .NET/Mono so I'm not certain that `gmcs` has been removed in 4.0, but if that's correct then mono-addins will probably need to be modified to have a dependency on Mono 3 specifically.

I didn't make this change in the other MonoDevelop's ebuilds because I hadn't tested them, but for anyone attempting to merge them on a system with this overlay's Mono 4 the same change will likely need to be made.