### PR TITLE
dev-lang/mono-9999: git-2 -> git-r3

### DIFF
--- a/dev-lang/mono/mono-9999.ebuild
+++ b/dev-lang/mono/mono-9999.ebuild
@@ -5,13 +5,12 @@
 EAPI="5"
 AUTOTOOLS_PRUNE_LIBTOOL_FILES="all"
 
-inherit linux-info mono-env flag-o-matic pax-utils autotools-utils git-2
+inherit linux-info mono-env flag-o-matic pax-utils autotools-utils git-r3
 
 DESCRIPTION="Mono runtime and class libraries, a C# compiler/interpreter"
 HOMEPAGE="http://www.mono-project.com/Main_Page"
 
 EGIT_REPO_URI="git://github.com/mono/${PN}.git"
-EGIT_HAS_SUBMODULES="true"
 
 LICENSE="MIT LGPL-2.1 GPL-2 BSD-4 NPL-1.1 Ms-PL GPL-2-with-linking-exception IDPL"
 SLOT="0"


### PR DESCRIPTION
Hi Heather and friends. With git 2.5.x it's been complaining to me about an unknown `-u` option to `git clone`. I'm pretty sure that's due to all the sloppy code in git-2.eclass and would probably be fine if that were cleaned up. However mono-9999 works fine with git-r3 (all submodules seem to update no problem).

Also it looks like this ebuild hasn't been touched in a while. I'm not sure what if anything from 4.2.0.179 is applicable here. I can't test a lot of the non-x86 and VB-only patches but I'll do some experiments and see what happens.

Here's the `./configure --help` after `src-prepare` as of yesterday if anybody's interested. https://gist.github.com/ormaaj/d8ed8e3acab0412af41c