### PR TITLE
Remove references to ppc patch no longer required as of mono-4.2.0

### DIFF
--- a/dev-lang/mono/mono-4.2.0.179.ebuild
+++ b/dev-lang/mono/mono-4.2.0.179.ebuild
@@ -67,11 +67,6 @@ src_prepare() {
 	# http://osdir.com/ml/general/2015-05/msg20808.html
 	epatch "${FILESDIR}/add_missing_vb_portable_targets.patch"
 
-	# Fix build on big-endian machines
-	# https://bugzilla.xamarin.com/show_bug.cgi?id=31779
-	# epatch "${FILESDIR}/${PN}-4.0.2.5-fix-decimal-ms-on-big-endian.patch"
-	#  * Failed Patch: mono-4.0.2.5-fix-decimal-ms-on-big-endian.patch !
-
 	# Fix build when sgen disabled
 	# https://bugzilla.xamarin.com/show_bug.cgi?id=32015
 	epatch "${FILESDIR}/${PN}-4.0.2.5-fix-mono-dis-makefile-am-when-without-sgen.patch"

--- a/dev-lang/mono/mono-4.2.1.36.ebuild
+++ b/dev-lang/mono/mono-4.2.1.36.ebuild
@@ -67,11 +67,6 @@ src_prepare() {
 	# http://osdir.com/ml/general/2015-05/msg20808.html
 	epatch "${FILESDIR}/add_missing_vb_portable_targets.patch"
 
-	# Fix build on big-endian machines
-	# https://bugzilla.xamarin.com/show_bug.cgi?id=31779
-	# epatch "${FILESDIR}/${PN}-4.0.2.5-fix-decimal-ms-on-big-endian.patch"
-	#  * Failed Patch: mono-4.0.2.5-fix-decimal-ms-on-big-endian.patch !
-
 	# Fix build when sgen disabled
 	# https://bugzilla.xamarin.com/show_bug.cgi?id=32015
 	epatch "${FILESDIR}/${PN}-4.0.2.5-fix-mono-dis-makefile-am-when-without-sgen.patch"


### PR DESCRIPTION
Verified on a Mac G4 Cube