### PR TITLE
dev-lang/mono: do not call paxctl directly

### DIFF
--- a/dev-lang/mono/mono-3.10.0.ebuild
+++ b/dev-lang/mono/mono-3.10.0.ebuild
@@ -46,13 +46,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-3.12.1.ebuild
+++ b/dev-lang/mono/mono-3.12.1.ebuild
@@ -46,13 +46,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-4.0.2.5.ebuild
+++ b/dev-lang/mono/mono-4.0.2.5.ebuild
@@ -50,13 +50,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-4.0.3.20.ebuild
+++ b/dev-lang/mono/mono-4.0.3.20.ebuild
@@ -51,13 +51,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-4.2.0.179.ebuild
+++ b/dev-lang/mono/mono-4.2.0.179.ebuild
@@ -51,13 +51,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-4.2.1.102-r1.ebuild
+++ b/dev-lang/mono/mono-4.2.1.102-r1.ebuild
@@ -51,13 +51,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-4.2.2.10.ebuild
+++ b/dev-lang/mono/mono-4.2.2.10.ebuild
@@ -51,13 +51,14 @@ pkg_setup() {
 
 src_prepare() {
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
 
 		# issue 9 : https://github.com/Heather/gentoo-dotnet/issues/9
-		sed '/exec "/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
+		sed '/exec "/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in || die "Failed to sed mono-wrapper.in"
 	fi
 
 	# mono build system can fail otherwise

--- a/dev-lang/mono/mono-9999.ebuild
+++ b/dev-lang/mono/mono-9999.ebuild
@@ -47,11 +47,12 @@ src_prepare() {
 
 	eautoreconf
 	# we need to sed in the paxctl-ng -mr in the runtime/mono-wrapper.in so it don't
-	# get killed in the build proces when MPROTEC is enable. #286280
+	# get killed in the build proces when MPROTECT is enable. #286280
 	# RANDMMAP kill the build proces to #347365
+	# use paxmark.sh to get PT/XT logic #532244
 	if use pax_kernel ; then
 		ewarn "We are disabling MPROTECT on the mono binary."
-		sed '/exec/ i\paxctl-ng -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in
+		sed '/exec/ i\paxmark.sh -mr "$r/@mono_runtime@"' -i "${S}"/runtime/mono-wrapper.in
 	fi
 
 	# mono build system can fail otherwise


### PR DESCRIPTION
paxmark.sh should be used instead which follows XT/PT marks correctly

Gentoo-Bug: https://bugs.gentoo.org/532244

I fixed this in the main tree but bumps overwrite the fixes so needs to be fixed in the overlay too.