### PR TITLE
Change stable keywords to testing.

### DIFF
--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 SRC_URI="https://github.com/mrward/xdt/archive/Release-NuGet-${PV}-Mono.tar.gz -> xdt-for-monodevelop-${PV}.tar.gz"
 S=${WORKDIR}/xdt-Release-NuGet-${PV}-Mono
 
-KEYWORDS="x86 amd64"
+KEYWORDS="~x86 ~amd64"
 IUSE=""
 
 DEPEND="|| ( dev-lang/mono )"

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3.ebuild
@@ -15,7 +15,7 @@ SLOT="0"
 SRC_URI="https://github.com/mrward/xdt/archive/Release-NuGet-${PV}-Mono.tar.gz -> xdt-for-monodevelop-${PV}.tar.gz"
 S=${WORKDIR}/xdt-Release-NuGet-${PV}-Mono
 
-KEYWORDS="x86 amd64 ~ppc"
+KEYWORDS="~x86 ~amd64 ~ppc"
 IUSE=""
 
 DEPEND="|| ( dev-lang/mono )"


### PR DESCRIPTION
For consistency with the rest of the tree i think the package should have testing keywords.

Also the stable keywords were set in initial commits so does not signify that the package has been tested.
