### PR TITLE
dev-util/monodevelop-9999 builds

### DIFF
--- a/dev-util/monodevelop/monodevelop-9999.ebuild
+++ b/dev-util/monodevelop/monodevelop-9999.ebuild
@@ -1,57 +1,100 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
 EAPI=5
-inherit fdo-mime gnome2-utils dotnet versionator eutils git-2
+inherit fdo-mime gnome2-utils dotnet versionator eutils git-r3
 
 DESCRIPTION="Integrated Development Environment for .NET"
 HOMEPAGE="http://www.monodevelop.com/"
+LICENSE="LGPL-2 MIT"
+LICENSE+=" Apache-2.0" # fsharpbinding, monomac
+LICENSE+=" GPL-2" # ikvm, mono-tools
+LICENSE+=" GPL-2-with-classpath-exception" # ikvm
+LICENSE+=" GPL-2-with-linking-exception" # libgit2
 
-EGIT_REPO_URI="git://github.com/mono/monodevelop.git"
-EGIT_HAS_SUBMODULES=1
-
-LICENSE="GPL-2"
+KEYWORDS="~amd64 ~x86"
 SLOT="0"
-KEYWORDS=""
-IUSE="doc test"
 
-RDEPEND=">=dev-lang/mono-3.2.8
-	>=dev-dotnet/gnome-sharp-2.24.2-r1
+EGIT_COMMIT="${P}"
+EGIT_REPO_URI="git://github.com/mono/monodevelop.git"
+EGIT_SUBMODULES=( '*' ) # todo: replace certain submodules with system packages
+
+if [ "${PV}" == "9999" ]; then
+	EGIT_COMMIT="HEAD"
+	KEYWORDS=""
+fi
+
+USE_DOTNET="net45" # todo: necessary?
+IUSE="${USE_DOTNET} +subversion +git qtcurve test"
+
+COMMON_DEPEND="
+	>=dev-lang/mono-4.4.1
 	>=dev-dotnet/gtk-sharp-2.12.21:2
-	>=dev-dotnet/mono-addins-1.0[gtk]
-	doc? ( dev-util/mono-docbrowser )
-	>=dev-dotnet/xsp-2
+	>=dev-dotnet/nuget-2.8.7
+	dev-dotnet/referenceassemblies-pcl
+	>=dev-lang/fsharp-4.0.1.15
+	net-libs/libssh2"
+RDEPEND="${COMMON_DEPEND}
 	dev-util/ctags
 	sys-apps/dbus[X]
-	!<dev-util/monodevelop-boo-$(get_version_component_range 1-2)
-	!<dev-util/monodevelop-java-$(get_version_component_range 1-2)
-	!<dev-util/monodevelop-database-$(get_version_component_range 1-2)
-	!<dev-util/monodevelop-debugger-gdb-$(get_version_component_range 1-2)
-	!<dev-util/monodevelop-debugger-mdb-$(get_version_component_range 1-2)
-	!<dev-util/monodevelop-vala-$(get_version_component_range 1-2)"
-DEPEND="${RDEPEND}
+	>=www-servers/xsp-2
+	git? ( dev-vcs/git )
+	subversion? ( dev-vcs/subversion )"
+DEPEND="${COMMON_DEPEND}
 	dev-util/intltool
 	virtual/pkgconfig
 	sys-devel/gettext
-	x11-misc/shared-mime-info"
-MAKEOPTS="${MAKEOPTS} -j1" #nowarn
+	x11-misc/shared-mime-info
+	x11-terms/xterm
+	app-arch/unzip"
+
+S="${WORKDIR}/${P}/main"
+
+src_unpack() {
+	git-r3_fetch
+	git-r3_checkout
+	nuget restore "${S}"
+	default
+}
 
 src_prepare() {
-	# Set specific_version to prevent binding problem
-	# when gtk#-3 is installed alongside gtk#-2
+	# use system nuget
+	find "${S}" -name 'Makefile*' -exec sed -i 's|mono .nuget/NuGet.exe|nuget|g' {} + || die
+
+	# prevent binding problem when gtk#-3 is installed alongside gtk#-2
 	find "${S}" -name '*.csproj' -exec sed -i 's#<SpecificVersion>.*</SpecificVersion>#<SpecificVersion>True</SpecificVersion>#' {} + || die
+
+	# this fsharpbinding test won't build
+	sed -i 's|<Compile Include="TemplateTests.fs" />|<None Include="TemplateTests.fs" />|g' "${S}"/external/fsharpbinding/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj || die
+
+	use qtcurve && epatch -p2 "${FILESDIR}/kill-qtcurve-warning.patch"
+
+	# generate configure script but don't execute yet
+	NOCONFIGURE=1 ./autogen.sh
+
+	default
 }
 
 src_configure() {
-	if use test
-		then tests="--enable-tests"
-		else tests=""
-	fi
-	./configure \
-		--prefix=/usr \
-		--profile=stable \
-		"${tests}" || die
+	# env vars are added as the fix for https://github.com/gentoo/dotnet/issues/29
+	MCS=/usr/bin/dmcs CSC=/usr/bin/dmcs GMCS=/usr/bin/dmcs econf \
+		--disable-update-mimedb \
+		--disable-update-desktopdb \
+		--enable-monoextensions \
+		--enable-gnomeplatform \
+		--enable-release \
+		$(use_enable test tests) \
+		$(use_enable subversion) \
+		$(use_enable git)
+
+	# Main.sln file was created on the fly during econf
+
+	# https://github.com/mrward/xdt/issues/4
+	epatch -p2 "${FILESDIR}/mrward-xdt-issue-4.patch"
+
+	# https://github.com/gentoo/dotnet/issues/38
+	sed -i -E -e 's#(EXE_PATH=")(.*)(/lib/monodevelop/bin/MonoDevelop.exe")#\1'${EPREFIX}'/usr\3#g' "${S}/monodevelop" || die
 }
 
 pkg_preinst() {


### PR DESCRIPTION
I fixed up monodevelop-9999 so that it at least builds.  Unfortunately, it crashes immediately with no interesting errors.  I can't tell yet if it's an upstream bug or something wrong with the way I build it.