### PR TITLE
Make SparkleShare find Mono's System.dll

### DIFF
--- a/net-misc/sparkleshare/files/sparkleshare-1.4-mono-path.patch
+++ b/net-misc/sparkleshare/files/sparkleshare-1.4-mono-path.patch
@@ -1,0 +1,19 @@
+diff --git a/build/m4/shamrock/mono.m4 b/build/m4/shamrock/mono.m4
+index c40ecbf..b0699fb 100755
+--- a/build/m4/shamrock/mono.m4
++++ b/build/m4/shamrock/mono.m4
+@@ -57,7 +57,8 @@ AC_DEFUN([_SHAMROCK_CHECK_MONO_GAC_ASSEMBLIES],
+ 		AC_MSG_CHECKING([for Mono $2 GAC for $asm.dll])
+ 		if test \
+ 			-e "$($PKG_CONFIG --variable=libdir $1)/mono/$2/$asm.dll" -o \
+-			-e "$($PKG_CONFIG --variable=prefix $1)/lib/mono/$2/$asm.dll"; \
++			-e "$($PKG_CONFIG --variable=prefix $1)/lib/mono/$2/$asm.dll" -o \
++			-e "/usr/lib/mono/xbuild-frameworks/.NETPortable/v$2/$asm.dll"; \
+ 			then \
+ 			AC_MSG_RESULT([found])
+ 		else
+@@ -91,4 +92,3 @@ AC_DEFUN([SHAMROCK_CHECK_MONO2_4_0_GAC_ASSEMBLIES],
+ [
+ 	_SHAMROCK_CHECK_MONO_GAC_ASSEMBLIES(mono-2, 4.0, $*)
+ ])
+-

--- a/net-misc/sparkleshare/sparkleshare-1.4.ebuild
+++ b/net-misc/sparkleshare/sparkleshare-1.4.ebuild
@@ -25,6 +25,7 @@ COMMON_DEPEND=">=dev-lang/mono-2.8
 	>=dev-dotnet/gtk-sharp-2.99.1
 	>=dev-dotnet/notify-sharp-3.0
 	dev-dotnet/webkitgtk-sharp
+	>=dev-dotnet/referenceassemblies-pcl-4.6
 "
 RDEPEND="${COMMON_DEPEND}
 	>=dev-vcs/git-1.8
@@ -37,6 +38,7 @@ DEPEND="${COMMON_DEPEND}
 
 src_prepare() {
 	sed -i "/^SHAVE_INIT/d" configure.ac
+	epatch "${FILESDIR}/${P}-mono-path.patch"
 	eautoreconf
 }
 


### PR DESCRIPTION
On my system, SparkleShare 1.4's configure script did not find the required System.dll supplied by Mono. This had two reasons:

* The file is included in dev-dotnet/referenceassemblies-pcl, which was not installed on my system and which the ebuild did not depend on
* The configure script tries to find the path to System.dll using pkg-config's "prefix" and "libdir" variables (for the "mono" package), which are not set in Gentoo.

The first point was easy to fix, the second a bit harder: The cleanest way would probably be to set the variable in mono.pc, but that files belongs to the mono ebuild and I did not want to touch it. Thus, I patched the configure script to also look in the Gentoo-specific path.