### PR TITLE
Make BuildTools always select debian.8-x64 runtime

### DIFF
--- a/dev-dotnet/dotnet-cli/files/corefx-1.1.1-buildtools.patch
+++ b/dev-dotnet/dotnet-cli/files/corefx-1.1.1-buildtools.patch
@@ -1,13 +1,43 @@
---- packages/Microsoft.DotNet.BuildTools/1.0.26-prerelease-01121-01/lib/init-tools.sh.orig	2017-03-11 18:38:23.022702000 -0600
-+++ packages/Microsoft.DotNet.BuildTools/1.0.26-prerelease-01121-01/lib/init-tools.sh	2017-03-11 18:43:47.093702000 -0600
-@@ -47,7 +47,9 @@
-                 if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" ]]; then
-                 echo "Unsupported Ubuntu version, falling back to Ubuntu 14.04"
-                 __PUBLISH_RID=ubuntu.14.04-x64
+--- packages/Microsoft.DotNet.BuildTools/1.0.26-prerelease-01121-01/lib/init-tools.sh.orig	2017-04-27 23:44:58.528117115 +0300
++++ packages/Microsoft.DotNet.BuildTools/1.0.26-prerelease-01121-01/lib/init-tools.sh	2017-04-28 00:02:47.527856902 +0300
+@@ -32,39 +32,7 @@
+ fi
+ 
+ if [ -z "$__PUBLISH_RID" ]; then
+-    OSName=$(uname -s)
+-    case $OSName in
+-        Darwin)
+-            __PUBLISH_RID=osx.10.10-x64
+-            ;;
+-
+-        Linux)
+-            if [ ! -e /etc/os-release ]; then
+-                echo "Can not determine distribution, assuming Ubuntu 14.04"
+-                __PUBLISH_RID=ubuntu.14.04-x64
+-            else
+-                source /etc/os-release
+-                if [[ "$ID" == "ubuntu" && "$VERSION_ID" != "14.04" && "$VERSION_ID" != "16.04" ]]; then
+-                echo "Unsupported Ubuntu version, falling back to Ubuntu 14.04"
+-                __PUBLISH_RID=ubuntu.14.04-x64
 -                else
-+		elif [[ "$ID" == "gentoo" ]]; then
-+		__PUBLISH_RID=debian.8-x64
-+		else
-                 __PUBLISH_RID=$ID.$VERSION_ID-x64
-                 fi
-             fi
+-                __PUBLISH_RID=$ID.$VERSION_ID-x64
+-                fi
+-            fi
+-
+-            # RHEL bumps their OS Version with minor releases, but we only put the "rhel.7-x64" RID in our
+-            # tool runtime, since there's binary compatibility between minor versions.
+-
+-            if [[ $__PUBLISH_RID == rhel.7*-x64 ]]; then
+-                __PUBLISH_RID=rhel.7-x64
+-            fi
+-            ;;
+-
+-        *)
+-            echo "Unsupported OS '$OSName' detected. Downloading ubuntu-x64 tools."
+-            __PUBLISH_RID=ubuntu.14.04-x64
+-            ;;
+-    esac
++__PUBLISH_RID=debian.8-x64
+ fi
+ 
+ cp -R $__TOOLS_DIR/* $__TOOLRUNTIME_DIR


### PR DESCRIPTION
Gentoo is not the only portage-based distro. Others may lack /etc/os-release or have ID value != "gentoo".
E.g. Funtoo os-release file is either empty or has ID="funtoo" on systems installed with more recent stage builds.

Since this is solely ~amd64 ebuild, I think it's useless to assume there can be other runtimes required.