### PR TITLE
Compatibility with gcc6 / clang3.9

### DIFF
--- a/dev-dotnet/dotnet-cli/dotnet-cli-1.1.1-r1.ebuild
+++ b/dev-dotnet/dotnet-cli/dotnet-cli-1.1.1-r1.ebuild
@@ -46,7 +46,11 @@ DEPEND="${RDEPEND}
 	>=sys-devel/gettext-0.19.7"
 
 PATCHES=(
+	"${FILESDIR}/coreclr-${CORECLR_V1_0}-gcc6-clang39.patch"
+	"${FILESDIR}/coreclr-${CORECLR_V1_0}-clang39-commit-9db7fb1.patch"
 	"${FILESDIR}/coreclr-${CORECLR_V1_0}-icu57-commit-352df35.patch"
+	"${FILESDIR}/coreclr-${PV}-clang39-commit-9db7fb1.patch"
+	"${FILESDIR}/coreclr-${PV}-exceptionhandling.patch"
 	"${FILESDIR}/corefx-${PV}-init-tools-script.patch"
 	"${FILESDIR}/corefx-${PV}-run-script.patch"
 )

--- a/dev-dotnet/dotnet-cli/files/coreclr-1.0.6-clang39-commit-9db7fb1.patch
+++ b/dev-dotnet/dotnet-cli/files/coreclr-1.0.6-clang39-commit-9db7fb1.patch
@@ -1,0 +1,115 @@
+diff --git a/coreclr-1.0.6/src/debug/daccess/dacdbiimpl.cpp b/coreclr-1.0.6/src/debug/daccess/dacdbiimpl.cpp
+index 26e3d6c..59f217c 100644
+--- a/coreclr-1.0.6/src/debug/daccess/dacdbiimpl.cpp
++++ b/coreclr-1.0.6/src/debug/daccess/dacdbiimpl.cpp
+@@ -90,7 +90,6 @@ IDacDbiInterface::IAllocator * g_pAllocator = NULL;
+ //
+ 
+ // Need a class to serve as a tag that we can use to overload New/Delete.
+-#define forDbi (*(forDbiWorker *)NULL)
+ 
+ void * operator new(size_t lenBytes, const forDbiWorker &)
+ {
+diff --git a/coreclr-1.0.6/src/debug/ee/debugger.h b/coreclr-1.0.6/src/debug/ee/debugger.h
+index 6368647..59d1e66 100644
+--- a/coreclr-1.0.6/src/debug/ee/debugger.h
++++ b/coreclr-1.0.6/src/debug/ee/debugger.h
+@@ -3512,10 +3512,10 @@ class DebuggerEval
+  * ------------------------------------------------------------------------ */
+ 
+ class InteropSafe {};
+-#define interopsafe (*(InteropSafe*)NULL)
++SELECTANY InteropSafe interopsafe;
+ 
+ class InteropSafeExecutable {};
+-#define interopsafeEXEC (*(InteropSafeExecutable*)NULL)
++SELECTANY InteropSafeExecutable interopsafeEXEC;
+ 
+ #ifndef DACCESS_COMPILE
+ inline void * __cdecl operator new(size_t n, const InteropSafe&)
+diff --git a/coreclr-1.0.6/src/debug/ildbsymlib/symwrite.h b/coreclr-1.0.6/src/debug/ildbsymlib/symwrite.h
+index 055b8ec..54ab11a 100644
+--- a/coreclr-1.0.6/src/debug/ildbsymlib/symwrite.h
++++ b/coreclr-1.0.6/src/debug/ildbsymlib/symwrite.h
+@@ -839,7 +839,8 @@ class ArrayStorage
+         {
+             // Help mitigate the impact of buffer overflow
+             // Fail fast with a null-reference AV
+-            return *(static_cast<T*>(0)) ;
++            volatile char* nullPointer = nullptr;
++            *nullPointer;
+         }
+         return m_array[ i ];
+     }
+diff --git a/coreclr-1.0.6/src/debug/inc/dacdbiinterface.h b/coreclr-1.0.6/src/debug/inc/dacdbiinterface.h
+index e61e240..24c3e24 100644
+--- a/coreclr-1.0.6/src/debug/inc/dacdbiinterface.h
++++ b/coreclr-1.0.6/src/debug/inc/dacdbiinterface.h
+@@ -32,7 +32,7 @@
+ template<class T> void DeleteDbiMemory(T *p);
+ // Need a class to serve as a tag that we can use to overload New/Delete.
+ class forDbiWorker {};
+-#define forDbi (*(forDbiWorker *)NULL)
++SELECTANY forDbiWorker forDbi;
+ extern void * operator new(size_t lenBytes, const forDbiWorker &);
+ extern void * operator new[](size_t lenBytes, const forDbiWorker &);
+ extern void operator delete(void *p, const forDbiWorker &);
+diff --git a/coreclr-1.0.6/src/pal/src/exception/seh.cpp b/coreclr-1.0.6/src/pal/src/exception/seh.cpp
+index 473c490..ad09e02 100644
+--- a/coreclr-1.0.6/src/pal/src/exception/seh.cpp
++++ b/coreclr-1.0.6/src/pal/src/exception/seh.cpp
+@@ -274,7 +274,7 @@ SEHProcessException(PAL_SEHException* exception)
+                     {
+                         // The exception happened in the page right below the stack limit,
+                         // so it is a stack overflow
+-                        write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
++                        (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
+                         PROCAbort();
+                     }
+                 }
+diff --git a/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.cpp b/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.cpp
+index 4bef170..82061ac 100644
+--- a/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.cpp
++++ b/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.cpp
+@@ -277,7 +277,7 @@ DWORD TP_GetFullPathName(LPWSTR fileName, DWORD nBufferLength, LPWSTR lpBuffer)
+ 	return GetFullPathNameW(fileName, nBufferLength, lpBuffer, NULL);
+ #else
+ 	char nativeFullPath[MAX_PATH];
+-	realpath(HackyConvertToSTR(fileName), nativeFullPath);
++	(void)realpath(HackyConvertToSTR(fileName), nativeFullPath);
+ 	LPWSTR fullPathForCLR = HackyConvertToWSTR(nativeFullPath);
+ 	wcscpy_s(lpBuffer, MAX_PATH, fullPathForCLR);
+ 	return wcslen(lpBuffer);
+diff --git a/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.h b/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.h
+index 49e8f88..c196b0c 100644
+--- a/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.h
++++ b/coreclr-1.0.6/tests/src/Common/Platform/platformdefines.h
+@@ -87,7 +87,7 @@ typedef void* HMODULE;
+ typedef void* ULONG_PTR;
+ typedef unsigned error_t;
+ typedef void* LPVOID;
+-typedef char BYTE;
++typedef unsigned char BYTE;
+ typedef WCHAR OLECHAR;
+ #endif
+ 
+diff --git a/coreclr-1.0.6/tests/src/Interop/common/types.h b/coreclr-1.0.6/tests/src/Interop/common/types.h
+index 7d7f776..cb59c42 100755
+--- a/coreclr-1.0.6/tests/src/Interop/common/types.h
++++ b/coreclr-1.0.6/tests/src/Interop/common/types.h
+@@ -28,7 +28,7 @@ typedef void* HMODULE;
+ typedef void* ULONG_PTR;
+ typedef unsigned error_t;
+ typedef void* LPVOID;
+-typedef char BYTE;
++typedef unsigned char BYTE;
+ typedef WCHAR OLECHAR;
+ 
+ typedef unsigned int UINT_PTR;
+@@ -54,4 +54,4 @@ typedef int*  DWORD_PTR;
+ #define FALSE 0
+ #endif
+ 
+-#endif //_INTEROP_TYPES__H
+\ No newline at end of file
++#endif //_INTEROP_TYPES__H

--- a/dev-dotnet/dotnet-cli/files/coreclr-1.0.6-gcc6-clang39.patch
+++ b/dev-dotnet/dotnet-cli/files/coreclr-1.0.6-gcc6-clang39.patch
@@ -1,0 +1,26 @@
+diff -rupN a/coreclr-1.0.6/src/pal/src/include/pal/palinternal.h b/coreclr-1.0.6/src/pal/src/include/pal/palinternal.h
+--- a/coreclr-1.0.6/src/pal/src/include/pal/palinternal.h	2017-04-27 21:06:55.268009100 +0300
++++ b/coreclr-1.0.6/src/pal/src/include/pal/palinternal.h	2017-04-27 21:08:23.705175087 +0300
+@@ -567,6 +567,8 @@ function_name() to call the system's imp
+ #endif
+ #include <ctype.h>
+ 
++#define _GLIBCXX_INCLUDE_NEXT_C_HEADERS 1
++
+ #define _WITH_GETLINE
+ #include <stdio.h>
+ #include <stdlib.h>
+diff -rupN a/coreclr-1.0.6/src/pal/src/include/pal/sharedmemory.h b/coreclr-1.0.6/src/pal/src/include/pal/sharedmemory.h
+--- a/coreclr-1.0.6/src/pal/src/include/pal/sharedmemory.h	2017-04-27 21:06:55.268009100 +0300
++++ b/coreclr-1.0.6/src/pal/src/include/pal/sharedmemory.h	2017-04-27 21:07:44.351101225 +0300
+@@ -182,6 +182,10 @@ public:
+     virtual void Close(bool isAbruptShutdown, bool releaseSharedData)
+     {
+     }
++
++	virtual ~SharedMemoryProcessDataBase()
++	{
++	}
+ };
+ 
+ class SharedMemoryProcessDataHeader

--- a/dev-dotnet/dotnet-cli/files/coreclr-1.1.1-clang39-commit-9db7fb1.patch
+++ b/dev-dotnet/dotnet-cli/files/coreclr-1.1.1-clang39-commit-9db7fb1.patch
@@ -1,0 +1,115 @@
+diff --git a/coreclr-1.1.1/src/debug/daccess/dacdbiimpl.cpp b/coreclr-1.1.1/src/debug/daccess/dacdbiimpl.cpp
+index 26e3d6c..59f217c 100644
+--- a/coreclr-1.1.1/src/debug/daccess/dacdbiimpl.cpp
++++ b/coreclr-1.1.1/src/debug/daccess/dacdbiimpl.cpp
+@@ -90,7 +90,6 @@ IDacDbiInterface::IAllocator * g_pAllocator = NULL;
+ //
+ 
+ // Need a class to serve as a tag that we can use to overload New/Delete.
+-#define forDbi (*(forDbiWorker *)NULL)
+ 
+ void * operator new(size_t lenBytes, const forDbiWorker &)
+ {
+diff --git a/coreclr-1.1.1/src/debug/ee/debugger.h b/coreclr-1.1.1/src/debug/ee/debugger.h
+index 6368647..59d1e66 100644
+--- a/coreclr-1.1.1/src/debug/ee/debugger.h
++++ b/coreclr-1.1.1/src/debug/ee/debugger.h
+@@ -3512,10 +3512,10 @@ class DebuggerEval
+  * ------------------------------------------------------------------------ */
+ 
+ class InteropSafe {};
+-#define interopsafe (*(InteropSafe*)NULL)
++SELECTANY InteropSafe interopsafe;
+ 
+ class InteropSafeExecutable {};
+-#define interopsafeEXEC (*(InteropSafeExecutable*)NULL)
++SELECTANY InteropSafeExecutable interopsafeEXEC;
+ 
+ #ifndef DACCESS_COMPILE
+ inline void * __cdecl operator new(size_t n, const InteropSafe&)
+diff --git a/coreclr-1.1.1/src/debug/ildbsymlib/symwrite.h b/coreclr-1.1.1/src/debug/ildbsymlib/symwrite.h
+index 055b8ec..54ab11a 100644
+--- a/coreclr-1.1.1/src/debug/ildbsymlib/symwrite.h
++++ b/coreclr-1.1.1/src/debug/ildbsymlib/symwrite.h
+@@ -839,7 +839,8 @@ class ArrayStorage
+         {
+             // Help mitigate the impact of buffer overflow
+             // Fail fast with a null-reference AV
+-            return *(static_cast<T*>(0)) ;
++            volatile char* nullPointer = nullptr;
++            *nullPointer;
+         }
+         return m_array[ i ];
+     }
+diff --git a/coreclr-1.1.1/src/debug/inc/dacdbiinterface.h b/coreclr-1.1.1/src/debug/inc/dacdbiinterface.h
+index e61e240..24c3e24 100644
+--- a/coreclr-1.1.1/src/debug/inc/dacdbiinterface.h
++++ b/coreclr-1.1.1/src/debug/inc/dacdbiinterface.h
+@@ -32,7 +32,7 @@
+ template<class T> void DeleteDbiMemory(T *p);
+ // Need a class to serve as a tag that we can use to overload New/Delete.
+ class forDbiWorker {};
+-#define forDbi (*(forDbiWorker *)NULL)
++SELECTANY forDbiWorker forDbi;
+ extern void * operator new(size_t lenBytes, const forDbiWorker &);
+ extern void * operator new[](size_t lenBytes, const forDbiWorker &);
+ extern void operator delete(void *p, const forDbiWorker &);
+diff --git a/coreclr-1.1.1/src/pal/src/exception/seh.cpp b/coreclr-1.1.1/src/pal/src/exception/seh.cpp
+index 473c490..ad09e02 100644
+--- a/coreclr-1.1.1/src/pal/src/exception/seh.cpp
++++ b/coreclr-1.1.1/src/pal/src/exception/seh.cpp
+@@ -274,7 +274,7 @@ SEHProcessException(PAL_SEHException* exception)
+                     {
+                         // The exception happened in the page right below the stack limit,
+                         // so it is a stack overflow
+-                        write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
++                        (void)write(STDERR_FILENO, StackOverflowMessage, sizeof(StackOverflowMessage) - 1);
+                         PROCAbort();
+                     }
+                 }
+diff --git a/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.cpp b/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.cpp
+index 4bef170..82061ac 100644
+--- a/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.cpp
++++ b/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.cpp
+@@ -277,7 +277,7 @@ DWORD TP_GetFullPathName(LPWSTR fileName, DWORD nBufferLength, LPWSTR lpBuffer)
+ 	return GetFullPathNameW(fileName, nBufferLength, lpBuffer, NULL);
+ #else
+ 	char nativeFullPath[MAX_PATH];
+-	realpath(HackyConvertToSTR(fileName), nativeFullPath);
++	(void)realpath(HackyConvertToSTR(fileName), nativeFullPath);
+ 	LPWSTR fullPathForCLR = HackyConvertToWSTR(nativeFullPath);
+ 	wcscpy_s(lpBuffer, MAX_PATH, fullPathForCLR);
+ 	return wcslen(lpBuffer);
+diff --git a/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.h b/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.h
+index 49e8f88..c196b0c 100644
+--- a/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.h
++++ b/coreclr-1.1.1/tests/src/Common/Platform/platformdefines.h
+@@ -87,7 +87,7 @@ typedef void* HMODULE;
+ typedef void* ULONG_PTR;
+ typedef unsigned error_t;
+ typedef void* LPVOID;
+-typedef char BYTE;
++typedef unsigned char BYTE;
+ typedef WCHAR OLECHAR;
+ #endif
+ 
+diff --git a/coreclr-1.1.1/tests/src/Interop/common/types.h b/coreclr-1.1.1/tests/src/Interop/common/types.h
+index 7d7f776..cb59c42 100755
+--- a/coreclr-1.1.1/tests/src/Interop/common/types.h
++++ b/coreclr-1.1.1/tests/src/Interop/common/types.h
+@@ -28,7 +28,7 @@ typedef void* HMODULE;
+ typedef void* ULONG_PTR;
+ typedef unsigned error_t;
+ typedef void* LPVOID;
+-typedef char BYTE;
++typedef unsigned char BYTE;
+ typedef WCHAR OLECHAR;
+ 
+ typedef unsigned int UINT_PTR;
+@@ -54,4 +54,4 @@ typedef int*  DWORD_PTR;
+ #define FALSE 0
+ #endif
+ 
+-#endif //_INTEROP_TYPES__H
+\ No newline at end of file
++#endif //_INTEROP_TYPES__H

--- a/dev-dotnet/dotnet-cli/files/coreclr-1.1.1-exceptionhandling.patch
+++ b/dev-dotnet/dotnet-cli/files/coreclr-1.1.1-exceptionhandling.patch
@@ -1,0 +1,11 @@
+--- a/coreclr-1.1.1/src/vm/exceptionhandling.cpp.orig	2017-04-28 01:48:48.153258383 +0300
++++ a/coreclr-1.1.1/src/vm/exceptionhandling.cpp	2017-04-28 01:50:38.150431673 +0300
+@@ -4730,7 +4730,7 @@
+         }
+     }
+ 
+-    throw ex;
++    throw std::move(ex);
+ }
+ 
+ #ifdef _AMD64_


### PR DESCRIPTION
Well, all these patches are either were already present for older coreclr versions or found in upstream:
https://github.com/dotnet/coreclr/commit/7864b05cfcf16b1261962c5538e2f071759a1d9e
https://github.com/dotnet/coreclr/commit/9f4bf341ad236df7d16bbdba0c4111393ea141d2
https://github.com/dotnet/coreclr/commit/af5172c88b1a6753135ca4d4c01b4a4a479f8002
https://github.com/dotnet/coreclr/issues/7822#issuecomment-257947093

This allowed me to build dotnet-cli/dotnet-cli-1.1.1-r1 with GCC6 and Clang 3.9 successfully, yet I'm not sure whether these changes are backwards compatible with older GCC and Clang. Perhaps you can test it and this pull request can be of some use for you.