### PR TITLE
dev-dotnet/dbus-sharp: StrongName fix (similar to #305)

### DIFF
--- a/dev-dotnet/dbus-sharp/dbus-sharp-0.8.1.ebuild
+++ b/dev-dotnet/dbus-sharp/dbus-sharp-0.8.1.ebuild
@@ -33,3 +33,9 @@ src_prepare() {
 	eautoreconf
 	default
 }
+
+src_compile() {
+    default
+    # https://github.com/gentoo/dotnet/issues/305
+    sn -R src/dbus-sharp.dll dbus-sharp.snk
+}


### PR DESCRIPTION
This is similar to the issue in #305 where a lot of our ebuilds need to be changed to sign with sn (StrongName). Fixes dbus-sharp which is needed for Smuxi.