### PR TITLE
dev-dotnet/nuget fix for adding delay signed assembly to gac

### DIFF
--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r2.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r2.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+USE_DOTNET="net45"
+
+inherit dotnet eutils gac
+
+DESCRIPTION="Microsoft's Xml Document Transformation library"
+HOMEPAGE="https://github.com/mrward/xdt"
+LICENSE="Apache-2.0"
+SLOT="0"
+
+SRC_URI="https://github.com/mrward/xdt/archive/Release-NuGet-${PV}-Mono.tar.gz -> xdt-for-monodevelop-${PV}.tar.gz"
+S=${WORKDIR}/xdt-Release-NuGet-${PV}-Mono
+
+KEYWORDS="~amd64 ~x86 ~ppc"
+IUSE=""
+
+DEPEND="|| ( dev-lang/mono )"
+RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	dotnet_pkg_setup
+}
+
+src_prepare() {
+	eapply "${FILESDIR}/disable-testproject-build-in-sln-r1.patch"
+	cp "${FILESDIR}/rsa-4096.snk" "${S}/XmlTransform" || die
+	eapply "${FILESDIR}/add-keyfile-option-to-csproj-r1.patch"
+	sed -i -e "s/1.0.0/${PV}/g"  "${S}/XmlTransform/Properties/AssemblyInfo.cs" || die
+	eapply_user
+}
+
+src_configure() {
+	export EnableNuGetPackageRestore="true"
+}
+
+src_compile() {
+	exbuild Microsoft.Web.XmlTransform.sln
+	elog "Signing XmlTransform.dll with rsa-4096.snk"
+	sn -R XmlTransform/bin/Release/Microsoft.Web.XmlTransform.dll XmlTransform/rsa-4096.snk
+}
+
+src_install() {
+	elog "Installing Microsoft.Web.XmlTransform.dll to GAC"
+	egacinstall XmlTransform/bin/Release/Microsoft.Web.XmlTransform.dll
+}

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3-r1.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3-r1.ebuild
@@ -1,0 +1,48 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+USE_DOTNET="net45"
+
+inherit dotnet eutils gac
+
+DESCRIPTION="Microsoft's Xml Document Transformation library"
+HOMEPAGE="https://github.com/mrward/xdt"
+LICENSE="Apache-2.0"
+SLOT="0"
+
+SRC_URI="https://github.com/mrward/xdt/archive/Release-NuGet-${PV}-Mono.tar.gz -> xdt-for-monodevelop-${PV}.tar.gz"
+S=${WORKDIR}/xdt-Release-NuGet-${PV}-Mono
+
+KEYWORDS="~x86 ~amd64 ~ppc"
+IUSE=""
+
+DEPEND="|| ( dev-lang/mono )"
+RDEPEND="${DEPEND}"
+
+pkg_setup() {
+	dotnet_pkg_setup
+}
+
+src_prepare() {
+	epatch "${FILESDIR}/disable-testproject-build-in-sln.patch"
+	cp "${FILESDIR}/rsa-4096.snk" "${S}/XmlTransform" || die
+	epatch "${FILESDIR}/add-keyfile-option-to-csproj.patch"
+	sed -i -e "s/1.0.0/${PV}/g"  "${S}/XmlTransform/Properties/AssemblyInfo.cs" || die
+	eapply_user
+}
+
+src_configure() {
+	export EnableNuGetPackageRestore="true"
+}
+
+src_compile() {
+	exbuild Microsoft.Web.XmlTransform.sln
+	elog "Signing Microsoft.Web.XmlTransform.dll with rsa-4096.snk"
+	sn -R XmlTransform/bin/Release/Microsoft.Web.XmlTransform.dll XmlTransform/rsa-4096.snk
+}
+
+src_install() {
+	elog "Installing Microsoft.Web.XmlTransform.dll to GAC"
+	egacinstall XmlTransform/bin/Release/Microsoft.Web.XmlTransform.dll
+}


### PR DESCRIPTION
As recently with nuget, I created two incremented -r ebuilds (2.8.1-r2 and 2.8.3-r1) just adding and elog and sn -R at the end of src_compile.  I still have two questions:

Generic and just for information - I'm curious how the Manifest gets updated to reflect the new ebuild(s) before someone downloads it with layman.

I only actually tested the xdt-for-monodevelop-2.8.1-r2, since the latest nuget version I have (2.8.7) has a depend of <=xdt-for-monodevelop-2.8.2.  I suppose I could change the depend, install 2.8.3-r1 but I could only test if nuget-2.8.3-r1 would build and install - I have no idea about the interactions and how to test in actual use.