### PR TITLE
dev-dotnet/irony-daxnet missing dependency added

### DIFF
--- a/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
+++ b/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
@@ -37,6 +37,7 @@ RDEPEND="${CDEPEND}
 	"
 
 DEPEND="${CDEPEND}
+	dev-dotnet/msbuildtasks
 	"
 
 PROJECT_PATH="src/Irony"

--- a/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
+++ b/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
@@ -17,7 +17,7 @@ SLOT="0"
 # pkg-config = register in pkg-config database
 USE_DOTNET="net45"
 inherit msbuild gac
-IUSE="+{USE_DOTNET}"
+IUSE="+${USE_DOTNET}"
 
 NAME="irony"
 HOMEPAGE="https://github.com/daxnet/${NAME}"


### PR DESCRIPTION
fix for https://bugs.gentoo.org/635894