### PR TITLE
Include xbuild functions in Newtonsoft and MSBuild tasks.

### DIFF
--- a/dev-dotnet/msbuild-tasks-api/msbuild-tasks-api-15.3-r1.ebuild
+++ b/dev-dotnet/msbuild-tasks-api/msbuild-tasks-api-15.3-r1.ebuild
@@ -10,7 +10,7 @@ SLOT="0"
 USE_DOTNET="net45"
 IUSE="+${USE_DOTNET} +gac developer debug doc"
 
-inherit gac dotnet
+inherit gac dotnet xbuild
 
 #https://github.com/mono/linux-packaging-msbuild/commit/0d8cee3f87b92cff425306d9c588fc6433fb6bf0
 GITHUB_ACCOUNT="mono"

--- a/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8-r1.ebuild
+++ b/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8-r1.ebuild
@@ -18,7 +18,7 @@ USE_DOTNET="net45"
 # pkg-config = register in pkg-config database
 IUSE="${USE_DOTNET} debug developer +gac pkg-config nupkg test"
 
-inherit dotnet gac
+inherit dotnet gac xbuild
 
 NAME="Newtonsoft.Json"
 HOMEPAGE="https://github.com/JamesNK/${NAME}"


### PR DESCRIPTION
Needed to install MSBuild, as the packages are required and their ebuilds
require the exbuild and exbuild_raw functions.