### PR TITLE
app-editors/visual-studio-code - fixes and version bump to 1.27.2

### DIFF
--- a/app-editors/visual-studio-code/visual-studio-code-1.26.1-r1.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.26.1-r1.ebuild
@@ -49,7 +49,7 @@ src_install() {
 	cp -pPR "${S}" "${D}/opt/${PN}" || die "Failed to copy files"
 	dosym "${EPREFIX}/opt/${PN}/bin/code" "/usr/bin/code"
 	make_desktop_entry "code" "Visual Studio Code" "${PN}" "Development;IDE"
-	doicon "${S}/resources/app/resources/linux/code.png"
+	newicon "${S}/resources/app/resources/linux/code.png" "${PN}.png"
 	insinto "/usr/share/licenses/${PN}"
 	newins "resources/app/LICENSE.txt" "LICENSE"
 }

--- a/app-editors/visual-studio-code/visual-studio-code-1.27.2.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.27.2.ebuild
@@ -1,0 +1,55 @@
+# Copyright 1999-2018 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+inherit eutils
+
+DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
+HOMEPAGE="https://code.visualstudio.com"
+BASE_URI="https://vscode-update.azurewebsites.net/${PV}"
+SRC_URI="amd64? ( ${BASE_URI}/linux-x64/stable -> ${P}-amd64.tar.gz )
+	x86? ( ${BASE_URI}/linux-ia32/stable -> ${P}-x86.tar.gz )"
+RESTRICT="mirror strip bindist"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS="~x86 ~amd64"
+IUSE=""
+
+DEPEND=">=gnome-base/gconf-3.2.6-r4:2
+>=media-libs/libpng-1.2.46:0
+>=x11-libs/cairo-1.14.12:0
+>=x11-libs/gtk+-2.24.31-r1:2
+>=x11-libs/libXtst-1.2.3:0"
+
+RDEPEND="${DEPEND}
+>=app-crypt/libsecret-0.18.5:0[crypt]
+>=net-print/cups-2.1.4:0
+>=x11-libs/libnotify-0.7.7:0
+>=x11-libs/libXScrnSaver-1.2.2-r1:0"
+
+QA_PRESTRIPPED="opt/${PN}/code"
+QA_PREBUILT="opt/${PN}/code"
+
+pkg_setup() {
+	if use amd64; then
+		S="${WORKDIR}/VSCode-linux-x64"
+	elif use x86; then
+		S="${WORKDIR}/VSCode-linux-ia32"
+	else
+		# shouldn't be possible with -* special keyword
+		die
+	fi
+}
+
+src_install() {
+	dodir "/opt"
+	# Using doins -r would strip executable bits from all binaries
+	cp -pPR "${S}" "${D}/opt/${PN}" || die "Failed to copy files"
+	dosym "${EPREFIX}/opt/${PN}/bin/code" "/usr/bin/code"
+	make_desktop_entry "code" "Visual Studio Code" "${PN}" "Development;IDE"
+	newicon "${S}/resources/app/resources/linux/code.png" "${PN}.png"
+	insinto "/usr/share/licenses/${PN}"
+	newins "resources/app/LICENSE.txt" "LICENSE"
+}

--- a/app-editors/visual-studio-code/visual-studio-code-1.27.2.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.27.2.ebuild
@@ -5,6 +5,7 @@ EAPI=6
 
 inherit eutils
 
+EXEC_NAME=vscode
 DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
 HOMEPAGE="https://code.visualstudio.com"
 BASE_URI="https://vscode-update.azurewebsites.net/${PV}"
@@ -47,8 +48,8 @@ src_install() {
 	dodir "/opt"
 	# Using doins -r would strip executable bits from all binaries
 	cp -pPR "${S}" "${D}/opt/${PN}" || die "Failed to copy files"
-	dosym "${EPREFIX}/opt/${PN}/bin/code" "/usr/bin/code"
-	make_desktop_entry "code" "Visual Studio Code" "${PN}" "Development;IDE"
+	dosym "${EPREFIX}/opt/${PN}/bin/code" "/usr/bin/${EXEC_NAME}"
+	make_desktop_entry "${EXEC_NAME}" "Visual Studio Code" "${PN}" "Development;IDE"
 	newicon "${S}/resources/app/resources/linux/code.png" "${PN}.png"
 	insinto "/usr/share/licenses/${PN}"
 	newins "resources/app/LICENSE.txt" "LICENSE"


### PR DESCRIPTION
* Rename executable symlink from 'code' to 'vscode'
 
    The "code" name is too broad and may lead to name clashes
    so it's better to use short but well known "vscode" name.

* Bump 1.27.2
* Fix desktop icon name as it referenced as ${PN} by third parameter for make_desktop_entry command
