### PR TITLE
added mono-pkg-config import

### DIFF
--- a/dev-dotnet/nini/nini-1.1.0-r5.ebuild
+++ b/dev-dotnet/nini/nini-1.1.0-r5.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=6
 
-inherit mono-env dotnet multilib versionator gac
+inherit mono-env dotnet multilib versionator gac mono-pkg-config
 
 DESCRIPTION="Nini - A configuration library for .NET"
 HOMEPAGE="http://nini.sourceforge.net"


### PR DESCRIPTION
if you enable pkg-config you get an error that einstall_pc_file is not defined, because of the missing import of mono-pkg-config