### PR TITLE
Smuxi Fixes

### DIFF
--- a/net-irc/smuxi/smuxi-1.0.7.ebuild
+++ b/net-irc/smuxi/smuxi-1.0.7.ebuild
@@ -44,7 +44,7 @@ src_prepare() {
 
 	# https://github.com/meebey/smuxi/issues/86
 	# eautoreconf
-	./autogen.sh | die "Could not run autogen.sh"
+	./autogen.sh || die "Could not run autogen.sh"
 }
 
 src_configure() {

--- a/net-irc/smuxi/smuxi-9999.ebuild
+++ b/net-irc/smuxi/smuxi-9999.ebuild
@@ -31,6 +31,7 @@ CDEPEND=">=dev-lang/mono-4.0.2.5
 DEPEND="${CDEPEND}
 	>=dev-util/intltool-0.25
 	>=sys-devel/gettext-0.17
+	>=net-misc/x11-ssh-askpass-1.2.4.1-r1
 	virtual/pkgconfig
 "
 RDEPEND="${CDEPEND}"

--- a/net-irc/smuxi/smuxi-9999.ebuild
+++ b/net-irc/smuxi/smuxi-9999.ebuild
@@ -47,7 +47,7 @@ src_prepare() {
 
 	# https://github.com/meebey/smuxi/issues/86
 	# eautoreconf
-	./autogen.sh | die "Could not run autogen.sh"
+	./autogen.sh || die "Could not run autogen.sh"
 }
 
 src_configure() {


### PR DESCRIPTION
tried to get the smuxi-1.0.7 to build still fails
but the smuxi-9999 builds now

needed to add a dependency for x11-ssh-askpass
is needed for password protected keys when you connect to a external engine via ssh+key