### PR TITLE
[visual-studio-code]: add missing dependencies

### DIFF
--- a/app-editors/visual-studio-code/visual-studio-code-1.39.2.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.39.2.ebuild
@@ -26,6 +26,7 @@ DEPEND=">=gnome-base/gconf-3.2.6-r4:2
 RDEPEND="${DEPEND}
 >=app-crypt/libsecret-0.18.5:0[crypt]
 >=net-print/cups-2.1.4:0
+>=dev-libs/libdbusmenu-16.04.0
 >=x11-libs/libnotify-0.7.7:0
 >=x11-libs/libXScrnSaver-1.2.2-r1:0"
 


### PR DESCRIPTION
According to [this][1], vscode need `dev-libs/libdbusmenu` installed to pass the menu to Plasma.

[1]: https://wiki.archlinux.org/index.php/Visual_Studio_Code#Global_menu_not_working_in_KDE/Plasma