### PR TITLE
[dotnetcore-sdk-bin-common]: version ${PV}-r* should be accepted

### DIFF
--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.0.100.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.0.100.ebuild
@@ -23,7 +23,7 @@ RESTRICT="splitdebug"
 # dotnetcore-sdk is the source based build
 
 RDEPEND="
-	=dev-dotnet/dotnetcore-sdk-bin-${PV}
+	=dev-dotnet/dotnetcore-sdk-bin-${PVR}
 	!dev-dotnet/dotnetcore-sdk-bin:0"
 
 S=${WORKDIR}


### PR DESCRIPTION
You can't install `dev-dotnet/dotnetcore-sdk-bin-3.0.100-r1` now, cause `dev-dotnet/dotnetcore-sdk-bin-common-3.0.100` need `dev-dotnet/dotnetcore-sdk-bin-3.0.100`.

I think at least `${PV}-r*` is acceptable.