### PR TITLE
dev-dotnet/dotnetcore-sdk-bin-common: fix dependencies if there are revisions

### DIFF
--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-2.1.802.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-2.1.802.ebuild
@@ -23,7 +23,7 @@ RESTRICT="splitdebug"
 # dotnetcore-sdk is the source based build
 
 RDEPEND="
-	=dev-dotnet/dotnetcore-sdk-bin-${PV}
+	~dev-dotnet/dotnetcore-sdk-bin-${PV}
 	!dev-dotnet/dotnetcore-sdk-bin:0"
 
 S=${WORKDIR}

--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-2.2.402.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-2.2.402.ebuild
@@ -23,7 +23,7 @@ RESTRICT="splitdebug"
 # dotnetcore-sdk is the source based build
 
 RDEPEND="
-	=dev-dotnet/dotnetcore-sdk-bin-${PV}
+	~dev-dotnet/dotnetcore-sdk-bin-${PV}
 	!dev-dotnet/dotnetcore-sdk-bin:0"
 
 S=${WORKDIR}

--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.0.100.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.0.100.ebuild
@@ -23,7 +23,7 @@ RESTRICT="splitdebug"
 # dotnetcore-sdk is the source based build
 
 RDEPEND="
-	=dev-dotnet/dotnetcore-sdk-bin-${PV}
+	~dev-dotnet/dotnetcore-sdk-bin-${PV}
 	!dev-dotnet/dotnetcore-sdk-bin:0"
 
 S=${WORKDIR}

--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.1.100_pre1.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.1.100_pre1.ebuild
@@ -23,7 +23,7 @@ RESTRICT="splitdebug"
 # dotnetcore-sdk is the source based build
 
 RDEPEND="
-	=dev-dotnet/dotnetcore-sdk-bin-${PV}
+	~dev-dotnet/dotnetcore-sdk-bin-${PV}
 	!dev-dotnet/dotnetcore-sdk-bin:0"
 
 S=${WORKDIR}


### PR DESCRIPTION
I think this is the proper fix for the problem in #445 , please merge this as otherwise it's currently not working for the 3.0 slot.