### PR TITLE
app-editors/visual-studio-code: update dependencies

### DIFF
--- a/app-editors/visual-studio-code/visual-studio-code-1.41.1.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.41.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7
@@ -17,18 +17,19 @@ SLOT="0"
 KEYWORDS="~amd64"
 IUSE=""
 
-DEPEND=">=gnome-base/gconf-3.2.6-r4:2
->=media-libs/libpng-1.2.46:0
->=x11-libs/cairo-1.14.12:0
->=x11-libs/gtk+-2.24.31-r1:2
->=x11-libs/libXtst-1.2.3:0"
-
+DEPEND=""
 RDEPEND="${DEPEND}
 >=app-crypt/libsecret-0.18.5:0[crypt]
->=net-print/cups-2.1.4:0
 >=dev-libs/libdbusmenu-16.04.0
+>=dev-libs/nss-3.47.1-r1:0
+>=media-libs/alsa-lib-1.1.8:0
+>=media-libs/libpng-1.2.46:0
+>=net-print/cups-2.1.4:0
+>=x11-libs/cairo-1.14.12:0
+>=x11-libs/gtk+-2.24.31-r1:2
 >=x11-libs/libnotify-0.7.7:0
->=x11-libs/libXScrnSaver-1.2.2-r1:0"
+>=x11-libs/libXScrnSaver-1.2.2-r1:0
+>=x11-libs/libXtst-1.2.3:0"
 
 QA_PRESTRIPPED="opt/${PN}/code"
 QA_PREBUILT="opt/${PN}/code"
@@ -36,8 +37,6 @@ QA_PREBUILT="opt/${PN}/code"
 pkg_setup() {
 	if use amd64; then
 		S="${WORKDIR}/VSCode-linux-x64"
-	elif use x86; then
-		S="${WORKDIR}/VSCode-linux-ia32"
 	else
 		# shouldn't be possible with -* special keyword
 		die


### PR DESCRIPTION
Added missing dev-libs/nss and media-libs/alsa-lib dependencies and
removed gnome-base/gconf which is not used (and that package has
problems with python3-only systems).
Also moved all the dependencies into RDEPEND and removed some leftover
x86-only code which is no longer supported.