### PR TITLE
add env variable for run programs

### DIFF
--- a/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.1.102.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin-common/dotnetcore-sdk-bin-common-3.1.102.ebuild
@@ -52,4 +52,8 @@ src_install() {
 	local ddest="${D}/${dest}"
 	cp -a "${S}"/* "${ddest}/" || die
 	dosym "/${dest}/dotnet" "/usr/bin/dotnet"
+
+	# set an env-variable for 3rd party tools
+	echo -n "DOTNET_ROOT=/${dest}" > "${T}/90dotnet"
+	doenvd "${T}/90dotnet"
 }


### PR DESCRIPTION
without this variable, compiled programs can't find runtime:
```
A fatal error occurred. The required library libhostfxr.so could not be found.
If this is a self-contained application, that library should exist in [/mnt/p/src/my/dotnet/test/bin/Debug/netcoreapp3.1/].
If this is a framework-dependent application, install the runtime in the global location [/usr/share/dotnet] or use the DOTNET_ROOT environment variable to specify the runtime location or register the runtime location in [/etc/dotnet/install_location].

The .NET Core runtime can be found at:
  - https://aka.ms/dotnet-core-applaunch?missing_runtime=true&arch=x64&rid=gentoo-x64
```