### PR TITLE
dev-dotnet/mono-addins-1.3.3: mark ~amd64 via dependency on ~amd64 mono

### DIFF
--- a/dev-dotnet/mono-addins/mono-addins-1.3.3.ebuild
+++ b/dev-dotnet/mono-addins/mono-addins-1.3.3.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://github.com/mono/${PN}/archive/${P}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"
-KEYWORDS="amd64 ~ppc ~x86"
+KEYWORDS="~amd64 ~ppc ~x86"
 IUSE="+gtk"
 
 RDEPEND=">=dev-lang/mono-6.0.0.334


### PR DESCRIPTION
A package with an `~amd64` dependency should not be `amd64` keyworded.  This fixes

```
!!! All ebuilds that could satisfy ">=dev-lang/mono-6.0.0.334" have been masked.
!!! One of the following masked packages is required to complete your request:
- dev-lang/mono-9999::dotnet (masked by: missing keyword)
- dev-lang/mono-6.6.0.161::gentoo (masked by: ~amd64 keyword)
- dev-lang/mono-6.4.0.198::gentoo (masked by: ~amd64 keyword)
- dev-lang/mono-6.0.0.334::gentoo (masked by: ~amd64 keyword)

(dependency required by "dev-dotnet/mono-addins-1.3.3::dotnet" [ebuild])
```