### PR TITLE
dev-util/fsharpbinding: Fix git eclass inherit and deprecated emacs dep

### DIFF
--- a/dev-util/fsharpbinding/fsharpbinding-9999.ebuild
+++ b/dev-util/fsharpbinding/fsharpbinding-9999.ebuild
@@ -1,11 +1,11 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="5"
 
-inherit git-2 elisp-common autotools dotnet eutils
+inherit git-r3 elisp-common autotools dotnet eutils
 
-EGIT_REPO_URI="git://github.com/fsharp/fsharpbinding.git"
+EGIT_REPO_URI="https://github.com/fsharp/fsharpbinding"
 
 DESCRIPTION="The F# Compiler"
 HOMEPAGE="https://github.com/fsharp/fsharpbinding"
@@ -19,7 +19,7 @@ IUSE="-emacs +monodevelop"
 MAKEOPTS="-j1" #nowarn
 DEPEND="dev-lang/fsharp
 	monodevelop? ( dev-util/monodevelop )
-	emacs? ( >=virtual/emacs-${NEED_EMACS:-21} app-emacs/s app-emacs/dash app-emacs/auto-complete )"
+	emacs? ( >=app-editors/emacs-${NEED_EMACS:-21} app-emacs/s app-emacs/dash app-emacs/auto-complete )"
 RDEPEND="${DEPEND}"
 
 pkg_setup() {
@@ -35,7 +35,7 @@ pkg_setup() {
 }
 
 src_unpack() {
-	git-2_src_unpack
+	git-r3_src_unpack
 	if use emacs; then
 		cd "${S}/emacs"
 		if [[ -f ${P}.el ]]; then


### PR DESCRIPTION
Package-Manager: Portage-2.3.99, Repoman-2.3.22
Signed-off-by: Adam Feldman <NP-Hardass@gentoo.org>