### PR TITLE
Update and rename dotnetcore-sdk-bin-5.0.100_pre6.ebuild to pre7 +arm/64 bins,

### DIFF
--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-5.0.100_pre7.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-5.0.100_pre7.ebuild
@@ -10,7 +10,9 @@ HOMEPAGE="https://www.microsoft.com/net/core"
 LICENSE="MIT"
 
 SRC_URI="
-amd64? ( https://download.visualstudio.microsoft.com/download/pr/ec4bba83-4586-4705-a6ae-c648861ca284/d9470c2f68161e3c2b8a0785fe7b3329/dotnet-sdk-5.0.100-preview.6.20318.15-linux-x64.tar.gz )
+amd64? ( https://download.visualstudio.microsoft.com/download/pr/6e9bdda1-72b5-4d2e-8908-be9321b8db26/cbc8ab6c3a1aca2a8dd92e272edd3293/dotnet-sdk-5.0.100-preview.7.20366.6-linux-x64.tar.gz )
+arm? ( https://download.visualstudio.microsoft.com/download/pr/20349622-b776-4fa0-a981-adacd7d57b9c/174f26a811b61a11a2132613e27f442a/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm.tar.gz )
+arm64? ( https://download.visualstudio.microsoft.com/download/pr/a7d933ce-5f1d-4c7b-a388-509ee6ee710c/152fa9acb7ee9cf34d7cb0eeeb36d448/dotnet-sdk-5.0.100-preview.7.20366.6-linux-arm64.tar.gz )
 "
 
 SLOT="5.0"


### PR DESCRIPTION
…e-sdk-bin-5.0.100_pre7.ebuild

http://gpo.zugaina.org/AJAX/Ebuild/52583204  Overlay: tresorit  newer. 
https://dotnet.microsoft.com/download/dotnet/thank-you/sdk-5.0.100-preview.7-linux-x64-binaries , arm/arm64 appended.