### PR TITLE
Allow merging dotnetcore bins with openssl-compat in order to support LibreSSL

### DIFF
--- a/dev-dotnet/dotnetcore-aspnet-bin/dotnetcore-aspnet-bin-2.0.3.ebuild
+++ b/dev-dotnet/dotnetcore-aspnet-bin/dotnetcore-aspnet-bin-2.0.3.ebuild
@@ -23,7 +23,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.4.ebuild
+++ b/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.4.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.6.ebuild
+++ b/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.6.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.7.ebuild
+++ b/dev-dotnet/dotnetcore-runtime-bin/dotnetcore-runtime-bin-2.0.7.ebuild
@@ -26,7 +26,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-2.1.809.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-2.1.809.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-2.2.207.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-2.2.207.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-3.0.103.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-3.0.103.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-3.1.401.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-3.1.401.ebuild
@@ -30,7 +30,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1

--- a/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-5.0.100_pre8.ebuild
+++ b/dev-dotnet/dotnetcore-sdk-bin/dotnetcore-sdk-bin-5.0.100_pre8.ebuild
@@ -31,7 +31,7 @@ RDEPEND="
 	>=sys-libs/libunwind-1.1-r1
 	>=dev-libs/icu-57.1
 	>=dev-util/lttng-ust-2.8.1
-	>=dev-libs/openssl-1.0.2h-r2
+	|| ( >=dev-libs/openssl-1.0.2h-r2 >=dev-libs/openssl-compat-1.0.2h-r2 )
 	>=net-misc/curl-7.49.0
 	>=app-crypt/mit-krb5-1.14.2
 	>=sys-libs/zlib-1.2.8-r1


### PR DESCRIPTION
I poked around with trying to run binaries on a machine with `dev-libs/libressl`, turns out that ABI is not that compatible for a proper .NET Core support.

The issue could be resolved by removing a direct dependency on OpenSSL by allowing building with `dev-libs/openssl-compat`, as @zigford already suggested. This could also fix #427.

I also noticed that `repoman` complains about headers being wrong but decided to leave it as is.