### PR TITLE
Fixed download URL for app-editors/vscode

### DIFF
--- a/app-editors/visual-studio-code/visual-studio-code-1.54.2.ebuild
+++ b/app-editors/visual-studio-code/visual-studio-code-1.54.2.ebuild
@@ -8,7 +8,7 @@ inherit eutils desktop
 EXEC_NAME=vscode
 DESCRIPTION="Multiplatform Visual Studio Code from Microsoft"
 HOMEPAGE="https://code.visualstudio.com"
-BASE_URI="https://vscode-update.azurewebsites.net/${PV}"
+BASE_URI="https://update.code.visualstudio.com/${PV}"
 SRC_URI="${BASE_URI}/linux-x64/stable -> ${P}-amd64.tar.gz"
 RESTRICT="mirror strip bindist"
 


### PR DESCRIPTION
As stated here there is a new download url for the package: https://vscode-update.azurewebsites.net/