### PR TITLE
Bump EAPI version of elisp.eclass users

### DIFF
--- a/app-emacs/dash/dash-9999.ebuild
+++ b/app-emacs/dash/dash-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="6"
 
 inherit git-r3 elisp
 

--- a/app-emacs/s/s-9999.ebuild
+++ b/app-emacs/s/s-9999.ebuild
@@ -1,7 +1,7 @@
-# Copyright 1999-2020 Gentoo Authors
+# Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="5"
+EAPI="6"
 
 inherit git-r3 elisp
 


### PR DESCRIPTION
The `elisp.eclass` doesn't support EAPI 5 anymore which leads to noisy errors during sync.

Closes #490.