### PR TITLE
mono-9999.ebuild autotools-utils -> autotools

### DIFF
--- a/dev-lang/mono/mono-9999.ebuild
+++ b/dev-lang/mono/mono-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI="5"
 AUTOTOOLS_PRUNE_LIBTOOL_FILES="all"
 
-inherit linux-info mono-env flag-o-matic pax-utils autotools-utils git-r3
+inherit linux-info mono-env flag-o-matic pax-utils autotools git-r3
 
 DESCRIPTION="Mono runtime and class libraries, a C# compiler/interpreter"
 HOMEPAGE="https://www.mono-project.com/Main_Page"


### PR DESCRIPTION
autotools-utils is outdated and is replaced with autotools, i wanted to fix that real quick.