### PR TITLE
Remove -gacdir parameter & force /usr/lib for every platform as mono GAC dir

### DIFF
--- a/dev-dotnet/buildtools/buildtools-1.0.27-r1.ebuild
+++ b/dev-dotnet/buildtools/buildtools-1.0.27-r1.ebuild
@@ -73,6 +73,6 @@ src_install() {
 	insinto "/usr/lib/mono/xbuild"
 	doins "${S}/src/Microsoft.DotNet.Build.Tasks/PackageFiles/resources.targets"
 	if use symlink; then
-		dosym "/usr/$(get_libdir)/mono/gac/${PROJ1}/1.0.27.0__0738eb9f132ed756/${PROJ1}.dll" "/usr/lib/mono/xbuild/${PROJ1}.dll"
+		dosym "/usr/lib/mono/gac/${PROJ1}/1.0.27.0__0738eb9f132ed756/${PROJ1}.dll" "/usr/lib/mono/xbuild/${PROJ1}.dll"
 	fi
 }

--- a/eclass/gac.eclass
+++ b/eclass/gac.eclass
@@ -28,14 +28,12 @@ egacinstall() {
 	if use gac; then
 		if use pkg-config; then
 			gacutil -i "${1}" \
-				-root "${ED}"/usr/$(get_libdir) \
-				-gacdir /usr/$(get_libdir) \
+				-root "${ED}"/usr/lib \
 				-package ${2:-${GACPN:-${PN}}} \
 				|| die "installing ${1} into the Global Assembly Cache failed"
 		else
 			gacutil -i "${1}" \
-				-root "${ED}"/usr/$(get_libdir) \
-				-gacdir /usr/$(get_libdir) \
+				-root "${ED}"/usr/lib \
 				|| die "installing ${1} into the Global Assembly Cache failed"
 		fi
 	fi
@@ -45,12 +43,11 @@ egacinstall() {
 # @DESCRIPTION:  install package to GAC
 egacadd() {
 	if use gac; then
-		GACROOT="${PREFIX}/usr/$(get_libdir)"
+		GACROOT="${PREFIX}/usr/lib"
 		GACDIR="/usr/$(get_libdir)/mono/gac"
-		einfo gacutil -i "${PREFIX}/${1}" -root "${GACROOT}" -gacdir "${GACDIR}"
+		einfo gacutil -i "${PREFIX}/${1}" -root "${GACROOT}"
 		gacutil -i "${PREFIX}/${1}" \
 			-root ${GACROOT} \
-			-gacdir ${GACDIR} \
 			|| die "installing ${1} into the Global Assembly Cache failed"
 	fi
 }
@@ -59,12 +56,11 @@ egacadd() {
 # @DESCRIPTION:  remove package from GAC
 egacdel() {
 	if use gac; then
-		GACROOT="${PREFIX}/usr/$(get_libdir)"
+		GACROOT="${PREFIX}/usr/lib"
 		GACDIR="/usr/$(get_libdir)/mono/gac"
-		einfo gacutil -u "${1}" -root "${GACROOT}" -gacdir "${GACDIR}"
+		einfo gacutil -u "${1}" -root "${GACROOT}"
 		gacutil -u "${1}" \
 			-root ${GACROOT} \
-			-gacdir ${GACDIR}
 		# don't die
 	fi
 }


### PR DESCRIPTION
https://github.com/gentoo/dotnet/issues/500
Mono uses `${prefix}/usr/lib` as GAC root, regardless of the bitnes of architecture. Also, according to MAN page of gacutil the -gacdir parameter is deprecated, and is there only for compatibility purposes. Also, in this case it was confusing, and redundant with -root parameter together.