### PR TITLE
upgrade EAPI usages to version 7, remove versionator dependency

### DIFF
--- a/app-editors/mypad/mypad-1.0.3_p201606130-r1.ebuild
+++ b/app-editors/mypad/mypad-1.0.3_p201606130-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/Open-NAT/Open-NAT-1.0.0-r201510290.ebuild
+++ b/dev-dotnet/Open-NAT/Open-NAT-1.0.0-r201510290.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit gac nupkg
 

--- a/dev-dotnet/antlr3-runtime/antlr3-runtime-3.5.2_beta1_p2017080216.ebuild
+++ b/dev-dotnet/antlr3-runtime/antlr3-runtime-3.5.2_beta1_p2017080216.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/aspnet-common/aspnet-common-1.0.0-r5.ebuild
+++ b/dev-dotnet/aspnet-common/aspnet-common-1.0.0-r5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/aspnet-configuration/aspnet-configuration-1.0.0-r5.ebuild
+++ b/dev-dotnet/aspnet-configuration/aspnet-configuration-1.0.0-r5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 USE_DOTNET="net45"

--- a/dev-dotnet/autofac-configuration/autofac-configuration-2.5.3.862.ebuild
+++ b/dev-dotnet/autofac-configuration/autofac-configuration-2.5.3.862.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/autofac-configuration/autofac-configuration-4.0.1-r5.ebuild
+++ b/dev-dotnet/autofac-configuration/autofac-configuration-4.0.1-r5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="4"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/autofac-web/autofac-web-2.5.3.862.ebuild
+++ b/dev-dotnet/autofac-web/autofac-web-2.5.3.862.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/autofac/autofac-2.5.3.862.ebuild
+++ b/dev-dotnet/autofac/autofac-2.5.3.862.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/autofac/autofac-3.5.2.ebuild
+++ b/dev-dotnet/autofac/autofac-3.5.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="3"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/autofac/autofac-4.1.1.ebuild
+++ b/dev-dotnet/autofac/autofac-4.1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="4"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/buildtools/buildtools-1.0.27-r1.ebuild
+++ b/dev-dotnet/buildtools/buildtools-1.0.27-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 RESTRICT="mirror"
 KEYWORDS="~amd64"

--- a/dev-dotnet/castle-core/castle-core-4.0.0_beta1.ebuild
+++ b/dev-dotnet/castle-core/castle-core-4.0.0_beta1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 USE_DOTNET="net45"

--- a/dev-dotnet/castle-dynamicproxy/castle-dynamicproxy-2.1.0.0.ebuild
+++ b/dev-dotnet/castle-dynamicproxy/castle-dynamicproxy-2.1.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 
 RESTRICT="mirror"

--- a/dev-dotnet/cecil/cecil-0.10_beta1_p2016102302-r1.ebuild
+++ b/dev-dotnet/cecil/cecil-0.10_beta1_p2016102302-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 RESTRICT+="mirror"
 

--- a/dev-dotnet/cecil/cecil-0.10_beta1_p2016111002-r1.ebuild
+++ b/dev-dotnet/cecil/cecil-0.10_beta1_p2016111002-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT+=" mirror"
 

--- a/dev-dotnet/cecil/cecil-0.9.6_p20160209-r1.ebuild
+++ b/dev-dotnet/cecil/cecil-0.9.6_p20160209-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 RESTRICT+=" mirror"
 

--- a/dev-dotnet/commandlineparser/commandlineparser-0.6.0_p20160115.ebuild
+++ b/dev-dotnet/commandlineparser/commandlineparser-0.6.0_p20160115.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6 # >=portage-2.2.25
+EAPI=7 # >=portage-2.2.25
 
 inherit versionator
 

--- a/dev-dotnet/conemu-control-winforms/conemu-control-winforms-1.0.0_p2016051802-r1.ebuild
+++ b/dev-dotnet/conemu-control-winforms/conemu-control-winforms-1.0.0_p2016051802-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 USE_DOTNET="net45"
 inherit gac dotnet

--- a/dev-dotnet/deveel-irony/deveel-irony-1.0.0_p20150328.ebuild
+++ b/dev-dotnet/deveel-irony/deveel-irony-1.0.0_p20150328.ebuild
@@ -15,7 +15,7 @@ IUSE="net45 debug +developer test +nupkg +gac +pkg-config"
 
 KEYWORDS="~amd64"
 
-inherit versionator gac nupkg
+inherit gac nupkg
 
 HOMEPAGE=https://github.com/deveel/irony
 NAME=irony
@@ -52,12 +52,12 @@ src_prepare() {
 }
 
 # PR 	Package revision, or r0 if no revision exists.
-NUSPEC_VERSION=$(get_version_component_range 1-3)"${PR//r/.}"
 ICON_URL=https://raw.githubusercontent.com/ArsenShnurkov/dotnet/deveeldb/dev-dotnet/${PN}/files/deveel-irony.png
 NUSPEC_FILE_NAME="Irony.nuspec"
 NUSPEC_ID="deveel-irony"
 
 src_compile() {
+	NUSPEC_VERSION=$(get_version_component_range 1-3)"${PR//r/.}"
 	exbuild /p:SignAssembly=true "/p:AssemblyOriginatorKeyFile=${WORKDIR}/mono.snk" "${METAFILETOBUILD}"
 
 	# run nuget_pack
@@ -94,6 +94,7 @@ EOF
 }
 
 src_install() {
+	NUSPEC_VERSION=$(get_version_component_range 1-3)"${PR//r/.}"
 	enupkg "${WORKDIR}/${NUSPEC_ID}.${NUSPEC_VERSION}.nupkg"
 
 	egacinstall "Irony/bin/${DIR}/Irony.dll"

--- a/dev-dotnet/deveel-irony/deveel-irony-1.0.0_p20150328.ebuild
+++ b/dev-dotnet/deveel-irony/deveel-irony-1.0.0_p20150328.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 # >=portage-2.2.25
 
 # debug = debug configuration (symbols and defines for debugging)

--- a/dev-dotnet/deveel-math/deveel-math-1.5.66-r201512290.ebuild
+++ b/dev-dotnet/deveel-math/deveel-math-1.5.66-r201512290.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit versionator gac nupkg
 

--- a/dev-dotnet/deveeldb/deveeldb-2.0_pre_alpha_p20160101.ebuild
+++ b/dev-dotnet/deveeldb/deveeldb-2.0_pre_alpha_p20160101.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 # !!! Unable to do any operations on 'dev-dotnet/DeveelDB-2.0_prealpha-r201601010',
 # !!! since its EAPI is higher than this portage version's. Please upgrade
 # !!! to a portage version that supports EAPI '6'.

--- a/dev-dotnet/dotnetzip-semverd/dotnetzip-semverd-1.9.3-r2.ebuild
+++ b/dev-dotnet/dotnetzip-semverd/dotnetzip-semverd-1.9.3-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/dryioc/dryioc-2.1.0_p201512110-r1.ebuild
+++ b/dev-dotnet/dryioc/dryioc-2.1.0_p201512110-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 # !!! Unable to do any operations on 'dev-dotnet/dryioc-2.1.0-r201512110',
 # !!! since its EAPI is higher than this portage version's. Please upgrade
 # !!! to a portage version that supports EAPI '6'.

--- a/dev-dotnet/eto-parse/eto-parse-1.4.0_p20150907-r1.ebuild
+++ b/dev-dotnet/eto-parse/eto-parse-1.4.0_p20150907-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 USE_DOTNET="net45"
 inherit mono-env gac nupkg versionator

--- a/dev-dotnet/fluent-nhibernate/fluent-nhibernate-2.0.2.ebuild
+++ b/dev-dotnet/fluent-nhibernate/fluent-nhibernate-2.0.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/gtk-sharp/gtk-sharp-2.12.21-r1.ebuild
+++ b/dev-dotnet/gtk-sharp/gtk-sharp-2.12.21-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit dotnet autotools
 

--- a/dev-dotnet/gtk-sharp/gtk-sharp-2.12.45.ebuild
+++ b/dev-dotnet/gtk-sharp/gtk-sharp-2.12.45.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit dotnet autotools
 

--- a/dev-dotnet/gtk-sharp/gtk-sharp-2.99.1-r1.ebuild
+++ b/dev-dotnet/gtk-sharp/gtk-sharp-2.99.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit dotnet autotools
 

--- a/dev-dotnet/gtk-sharp/gtk-sharp-2.99.3-r1.ebuild
+++ b/dev-dotnet/gtk-sharp/gtk-sharp-2.99.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit dotnet autotools
 

--- a/dev-dotnet/icsharpcodetexteditor/icsharpcodetexteditor-3.2.2-r20150630.ebuild
+++ b/dev-dotnet/icsharpcodetexteditor/icsharpcodetexteditor-3.2.2-r20150630.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit eutils gac nupkg
 

--- a/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
+++ b/dev-dotnet/irony-daxnet/irony-daxnet-1.0.0_p2017083101.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 
 RESTRICT="mirror"

--- a/dev-dotnet/libgit2sharp/libgit2sharp-0.22-r1.ebuild
+++ b/dev-dotnet/libgit2sharp/libgit2sharp-0.22-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT+=" mirror"

--- a/dev-dotnet/log4net/log4net-1.2.11-r2.ebuild
+++ b/dev-dotnet/log4net/log4net-1.2.11-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit eutils mono-env dotnet multilib versionator gac
 

--- a/dev-dotnet/microsoft-web-infrastructure/microsoft-web-infrastructure-1.0.0.0.ebuild
+++ b/dev-dotnet/microsoft-web-infrastructure/microsoft-web-infrastructure-1.0.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 USE_DOTNET="net45"
 inherit gac nupkg

--- a/dev-dotnet/mono-options/mono-options-4.4.0.0.ebuild
+++ b/dev-dotnet/mono-options/mono-options-4.4.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 # Watch the order of these!
 inherit nupkg

--- a/dev-dotnet/monotorrent/monotorrent-1.0.0_p2015101302.ebuild
+++ b/dev-dotnet/monotorrent/monotorrent-1.0.0_p2015101302.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/msbuild-defaulttasks/msbuild-defaulttasks-15.3-r3.ebuild
+++ b/dev-dotnet/msbuild-defaulttasks/msbuild-defaulttasks-15.3-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 RESTRICT="mirror"
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuild-roslyn-csc/msbuild-roslyn-csc-15.3-r1.ebuild
+++ b/dev-dotnet/msbuild-roslyn-csc/msbuild-roslyn-csc-15.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/msbuild-tasks-api/msbuild-tasks-api-15.3-r1.ebuild
+++ b/dev-dotnet/msbuild-tasks-api/msbuild-tasks-api-15.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 RESTRICT="mirror"
 KEYWORDS="~amd64"
 SLOT="0"

--- a/dev-dotnet/msbuildcontrib/msbuildcontrib-2014.06.05.01.ebuild
+++ b/dev-dotnet/msbuildcontrib/msbuildcontrib-2014.06.05.01.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.235.ebuild
+++ b/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.235.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240-r2.ebuild
+++ b/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240-r3.ebuild
+++ b/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240.ebuild
+++ b/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.240.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 SLOT="0"
 
 KEYWORDS="~amd64"

--- a/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.260_pre.ebuild
+++ b/dev-dotnet/msbuildtasks/msbuildtasks-1.5.0.260_pre.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/ndepend-path/ndepend-path-0.0_p20151123.ebuild
+++ b/dev-dotnet/ndepend-path/ndepend-path-0.0_p20151123.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8-r1.ebuild
+++ b/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 SLOT="0"
@@ -17,7 +17,7 @@ USE_DOTNET="net45"
 # pkg-config = register in pkg-config database
 IUSE="${USE_DOTNET} debug developer +gac pkg-config nupkg test"
 
-inherit dotnet gac xbuild versionator
+inherit dotnet gac xbuild
 
 NAME="Newtonsoft.Json"
 HOMEPAGE="https://github.com/JamesNK/${NAME}"

--- a/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8.ebuild
+++ b/dev-dotnet/newtonsoft-json/newtonsoft-json-6.0.8.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 

--- a/dev-dotnet/newtonsoft-json/newtonsoft-json-7.0.1_p20150831.ebuild
+++ b/dev-dotnet/newtonsoft-json/newtonsoft-json-7.0.1_p20150831.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 # debug = debug configuration (symbols and defines for debugging)
 # developer = generate symbols information (to view line numbers in stack traces, either in debug or release configuration)

--- a/dev-dotnet/newtonsoft-json/newtonsoft-json-8.0.1_p20151229.ebuild
+++ b/dev-dotnet/newtonsoft-json/newtonsoft-json-8.0.1_p20151229.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 # debug = debug configuration (symbols and defines for debugging)
 # developer = generate symbols information (to view line numbers in stack traces, either in debug or release configuration)

--- a/dev-dotnet/nhibernate-core/nhibernate-core-5.0.0.ebuild
+++ b/dev-dotnet/nhibernate-core/nhibernate-core-5.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/nhibernate-iesi-collections/nhibernate-iesi-collections-4.0.2.ebuild
+++ b/dev-dotnet/nhibernate-iesi-collections/nhibernate-iesi-collections-4.0.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 RESTRICT="mirror"
 KEYWORDS="~amd64"
 SLOT="0"

--- a/dev-dotnet/nhibernate-linq/nhibernate-linq-1.0.0.0_p2010050601.ebuild
+++ b/dev-dotnet/nhibernate-linq/nhibernate-linq-1.0.0.0_p2010050601.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/nini/nini-1.1.0-r5.ebuild
+++ b/dev-dotnet/nini/nini-1.1.0-r5.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit mono-env dotnet multilib versionator gac mono-pkg-config
 

--- a/dev-dotnet/nlog/nlog-4.3.11_p2016110901.ebuild
+++ b/dev-dotnet/nlog/nlog-4.3.11_p2016110901.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/npgsql/npgsql-3.1.6.ebuild
+++ b/dev-dotnet/npgsql/npgsql-3.1.6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 # debug = debug configuration (symbols and defines for debugging)
 # developer = generate symbols information (to view line numbers in stack traces, either in debug or release configuration)

--- a/dev-dotnet/nuget/nuget-2.8.7-r3.ebuild
+++ b/dev-dotnet/nuget/nuget-2.8.7-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 
 USE_DOTNET="net45"

--- a/dev-dotnet/nunit-framework/nunit-framework-3.7.0.ebuild
+++ b/dev-dotnet/nunit-framework/nunit-framework-3.7.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/pliant/pliant-0.5.0.1.ebuild
+++ b/dev-dotnet/pliant/pliant-0.5.0.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/referenceassemblies-pcl/referenceassemblies-pcl-4.6.ebuild
+++ b/dev-dotnet/referenceassemblies-pcl/referenceassemblies-pcl-4.6.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit rpm
 

--- a/dev-dotnet/remotion-linq-eagerfetching/remotion-linq-eagerfetching-2.1.0.ebuild
+++ b/dev-dotnet/remotion-linq-eagerfetching/remotion-linq-eagerfetching-2.1.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/remotion-linq/remotion-linq-2.1.2.ebuild
+++ b/dev-dotnet/remotion-linq/remotion-linq-2.1.2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-dotnet/sharpziplib/sharpziplib-0.86.0.518.ebuild
+++ b/dev-dotnet/sharpziplib/sharpziplib-0.86.0.518.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/sharpziplib/sharpziplib-0.86.0.762.ebuild
+++ b/dev-dotnet/sharpziplib/sharpziplib-0.86.0.762.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/slntools/slntools-1.1.3_p201508170-r1.ebuild
+++ b/dev-dotnet/slntools/slntools-1.1.3_p201508170-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 USE_DOTNET="net45"
 # cli = do install command line interface

--- a/dev-dotnet/smartirc4net/smartirc4net-1.0.ebuild
+++ b/dev-dotnet/smartirc4net/smartirc4net-1.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit mono-env dotnet autotools git-r3
 
 HOMEPAGE="https://www.smuxi.org/page/Download"

--- a/dev-dotnet/smartirc4net/smartirc4net-1.1.ebuild
+++ b/dev-dotnet/smartirc4net/smartirc4net-1.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit mono-env dotnet autotools git-r3
 
 HOMEPAGE="https://www.smuxi.org/page/Download"

--- a/dev-dotnet/system-collections-immutable/system-collections-immutable-2.0.0_pre-r1.ebuild
+++ b/dev-dotnet/system-collections-immutable/system-collections-immutable-2.0.0_pre-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 RESTRICT="mirror"
 KEYWORDS="~amd64"

--- a/dev-dotnet/system-reflection-metadata/system-reflection-metadata-2.0.0_pre-r1.ebuild
+++ b/dev-dotnet/system-reflection-metadata/system-reflection-metadata-2.0.0_pre-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 
 RESTRICT="mirror"
 KEYWORDS="~amd64"

--- a/dev-dotnet/system-web-mvc/system-web-mvc-5.2.3_p2014092400.ebuild
+++ b/dev-dotnet/system-web-mvc/system-web-mvc-5.2.3_p2014092400.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit mono-env gac nupkg versionator
 
 REPO_NAME="aspnetwebstack"

--- a/dev-dotnet/system-web-razor/system-web-razor-3.2.3_p2014092400.ebuild
+++ b/dev-dotnet/system-web-razor/system-web-razor-3.2.3_p2014092400.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit mono-env gac nupkg versionator
 
 REPO_NAME="aspnetwebstack"

--- a/dev-dotnet/system-web-webpages/system-web-webpages-3.2.3_p2014092400.ebuild
+++ b/dev-dotnet/system-web-webpages/system-web-webpages-3.2.3_p2014092400.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit mono-env gac nupkg versionator
 
 REPO_NAME="aspnetwebstack"

--- a/dev-dotnet/system-web/system-web-4.6.0.150.ebuild
+++ b/dev-dotnet/system-web/system-web-4.6.0.150.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 USE_DOTNET="net45"
 inherit gac dotnet

--- a/dev-dotnet/system-web/system-web-4.6.0.182-r2.ebuild
+++ b/dev-dotnet/system-web/system-web-4.6.0.182-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 USE_DOTNET="net45"
 inherit gac dotnet

--- a/dev-dotnet/techtalk-specflow/techtalk-specflow-1.2.0.0.ebuild
+++ b/dev-dotnet/techtalk-specflow/techtalk-specflow-1.2.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/x-pagedlist/x-pagedlist-1.24.0.23549-r201512120.ebuild
+++ b/dev-dotnet/x-pagedlist/x-pagedlist-1.24.0.23549-r201512120.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 inherit versionator gac nupkg
 

--- a/dev-dotnet/x-pagedlist/x-pagedlist-5.3.0.8.ebuild
+++ b/dev-dotnet/x-pagedlist/x-pagedlist-5.3.0.8.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r1.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 USE_DOTNET="net45"
 
 inherit dotnet eutils gac

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r2.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 USE_DOTNET="net45"
 
 inherit dotnet eutils gac xbuild

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 USE_DOTNET="net45"
 
 inherit dotnet eutils gac

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3-r1.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 USE_DOTNET="net45"
 
 inherit dotnet eutils gac

--- a/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3.ebuild
+++ b/dev-dotnet/xdt-for-monodevelop/xdt-for-monodevelop-2.8.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 USE_DOTNET="net45"
 
 inherit dotnet eutils gac

--- a/dev-lang/oscript/oscript-1.0.19.0_p2017102608.ebuild
+++ b/dev-lang/oscript/oscript-1.0.19.0_p2017102608.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-util/antlrcs/antlrcs-3.5.2_beta1_p2017080216.ebuild
+++ b/dev-util/antlrcs/antlrcs-3.5.2_beta1_p2017080216.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-util/mono-packaging-tools/mono-packaging-tools-1.4.3.ebuild
+++ b/dev-util/mono-packaging-tools/mono-packaging-tools-1.4.3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6 # >=portage-2.2.25
+EAPI=7 # >=portage-2.2.25
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-util/msbuild/msbuild-15.3-r3.ebuild
+++ b/dev-util/msbuild/msbuild-15.3-r3.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 RESTRICT="mirror"
 KEYWORDS="~amd64"
 SLOT="0"

--- a/dev-util/nant/nant-0.93.5019_p2016101703.ebuild
+++ b/dev-util/nant/nant-0.93.5019_p2016101703.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 KEYWORDS="~amd64"
 
 RESTRICT="mirror"

--- a/dev-util/nunit-console/nunit-console-3.7.0.ebuild
+++ b/dev-util/nunit-console/nunit-console-3.7.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 
 KEYWORDS="~amd64"
 RESTRICT="mirror"

--- a/dev-util/nunit-gui/nunit-gui-3.7.0.ebuild
+++ b/dev-util/nunit-gui/nunit-gui-3.7.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-util/nunit/nunit-2.6.4_p2015011102-r2.ebuild
+++ b/dev-util/nunit/nunit-2.6.4_p2015011102-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-util/nunit/nunit-3.0.1-r2.ebuild
+++ b/dev-util/nunit/nunit-3.0.1-r2.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI="6"
+EAPI="7"
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/dev-util/tartool/tartool-1.0.0.0.ebuild
+++ b/dev-util/tartool/tartool-1.0.0.0.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 KEYWORDS="~amd64"
 RESTRICT="mirror"
 

--- a/net-irc/smuxi/smuxi-1.0.6.130.ebuild
+++ b/net-irc/smuxi/smuxi-1.0.6.130.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit eutils gnome2-utils mono-env versionator
 
 DESCRIPTION="A flexible, irssi-like and user-friendly IRC client for the Gnome Desktop"

--- a/net-irc/smuxi/smuxi-1.0.7.ebuild
+++ b/net-irc/smuxi/smuxi-1.0.7.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=7
 inherit eutils gnome2-utils mono-env dotnet versionator autotools git-r3
 
 DESCRIPTION="A flexible, irssi-like and user-friendly IRC client for the Gnome Desktop"


### PR DESCRIPTION
- find & replace EAPI="6" with EAPI="7"
- find & replace EAPI=6 with EAPI=7
- single usage of inherited versionator.eclass removed - inheritance appeared not to be used

This works for me - no more EAPI errors, but I'm a complete n00b wrt ebuilds. Please check my homework.